### PR TITLE
Updated Fantom Windows Installer download link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ See [Setup](https://fantom.org/doc/docTools/Setup) for installation details.
 Installers are also available for macOS and Windows:
 
   * macOS: `brew install fantom`
-  * Windows: [fantom-1.0.74.exe](https://bitbucket.org/fantomfactory/fantom-windows-installer/downloads/fantom-1.0.74.exe)
+  * Windows: [fantom-1.0.74.exe](https://github.com/Fantom-Factory/fantomWindowsInstaller/releases)
 
 ## Community
 


### PR DESCRIPTION
The Fantom Windows Installer has been migrated to GitHub @ https://github.com/Fantom-Factory/fantomWindowsInstaller

Note I'm also consolidating a lot "Alien Factory" nomenclature to "[Fantom Factory](https://www.fantomfactory.com/)" - so if I may, I'd like to ask for the details on the new [Fantom download page](https://fantom.org/download) to be updated too.