### PR TITLE
web: add generic write(Str|Form|File) utils to WebClient

### DIFF
--- a/src/web/fan/WebClient.fan
+++ b/src/web/fan/WebClient.fan
@@ -305,21 +305,46 @@ class WebClient
   }
 
 //////////////////////////////////////////////////////////////////////////
-// Post
+// Post/Patch
 //////////////////////////////////////////////////////////////////////////
 
   **
-  ** Make a post request to the URI with the given form data.
-  ** Set the Content-Type to application/x-www-form-urlencoded.
-  ** Upon completion the response is ready to be read.  This method
-  ** does not support the ["Expect" header]`pod-doc#expectContinue` (it
-  ** posts all form data before reading response).
+  ** Convenience for 'writeForm("POST", form)'
   **
   This postForm(Str:Str form)
   {
+    writeForm("POST", form)
+  }
+
+  **
+  ** Convenience for 'writeStr("POST", content)'
+  **
+  This postStr(Str content)
+  {
+    writeStr("POST", content)
+  }
+
+  **
+  ** Convenience for 'writeFile("POST", file)'
+  **
+  This postFile(File file)
+  {
+    writeFile("POST", file)
+  }
+
+  **
+  ** Make a request with the given HTTP method to the URI with the given form data.
+  ** Set the Content-Type to application/x-www-form-urlencoded.
+  ** Upon completion the response is ready to be read.  This method
+  ** does not support the ["Expect" header]`pod-doc#expectContinue` (it
+  ** writes all form data before reading response). Should primarily be used for POST
+  ** and PATCH requests.
+  **
+  This writeForm(Str method, Str:Str form)
+  {
     if (reqHeaders["Expect"] != null) throw UnsupportedErr("'Expect' header")
     body := Uri.encodeQuery(form)
-    reqMethod = "POST"
+    reqMethod = method
     reqHeaders["Content-Type"] = "application/x-www-form-urlencoded"
     reqHeaders["Content-Length"] = body.size.toStr // encoded form is ASCII
     writeReq
@@ -329,18 +354,19 @@ class WebClient
   }
 
   **
-  ** Make a post request to the URI using UTF-8 encoding of given
+  ** Make a request with the given HTTP method to the URI using UTF-8 encoding of given
   ** string.  If Content-Type is not already set, then set it
   ** to "text/plain; charset=utf-8".  Upon completion the response
   ** is ready to be read.  This method does not support the
-  ** ["Expect" header]`pod-doc#expectContinue` (it posts full string
-  ** before reading response).
+  ** ["Expect" header]`pod-doc#expectContinue` (it writes full string
+  ** before reading response). Should primarily be used for "POST" and "PATCH"
+  ** requests.
   **
-  This postStr(Str content)
+  This writeStr(Str method, Str content)
   {
     if (reqHeaders["Expect"] != null) throw UnsupportedErr("'Expect' header")
     body := Buf().print(content).flip
-    reqMethod = "POST"
+    reqMethod = method
     ct := reqHeaders["Content-Type"]
     if (ct == null)
       reqHeaders["Content-Type"] = "text/plain; charset=utf-8"
@@ -352,16 +378,17 @@ class WebClient
   }
 
   **
-  ** Post a file to the URI.  If Content-Type header is not already
+  ** Write a file using the given HTTP method to the URI.  If Content-Type header is not already
   ** set, then it is set from the file extension's MIME type.  Upon
   ** completion the response is ready to be read.  This method does
   ** not support the ["Expect" header]`pod-doc#expectContinue` (it
-  ** posts full file before reading response).
+  ** writes full file before reading response). Should primarily be used for "POST" and
+  ** "PATCH" requests.
   **
-  This postFile(File file)
+  This writeFile(Str method, File file)
   {
     if (reqHeaders["Expect"] != null) throw UnsupportedErr("'Expect' header")
-    reqMethod = "POST"
+    reqMethod = method
     ct := reqHeaders["Content-Type"]
     if (ct == null)
       reqHeaders["Content-Type"] = file.mimeType?.toStr ?: "application/octet-stream"


### PR DESCRIPTION
Instead of adding new methods for `patchX` I created public `writeX` methods for WebClient, and changed `postX` to route to those as a convenience.