### PR TITLE
Removed "op" parameter from fan.sys.ObjUtil.equals()

### DIFF
--- a/src/sys/js/fan/ObjUtil.js
+++ b/src/sys/js/fan/ObjUtil.js
@@ -24,7 +24,7 @@ fan.sys.ObjUtil.hash = function(obj)
   return 0;
 }
 
-fan.sys.ObjUtil.equals = function(a, b, op)
+fan.sys.ObjUtil.equals = function(a, b)
 {
   if (a == null) return b == null;
   if (a instanceof fan.sys.Obj) return a.equals(b);


### PR DESCRIPTION
It doesn't look like it's being used - a copy/paste error from ObjUtil.compare() perhaps?