### PR TITLE
BigInt arithmetic

### DIFF
--- a/src/math/fan/BigInt.fan
+++ b/src/math/fan/BigInt.fan
@@ -4,6 +4,7 @@
 //
 // History:
 //   06 Aug 2021 Matthew Giannini Creation
+//   26 Feb 2023 Jeremy Criquet Added many of the common methods from java's BigInteger
 //
 
 **
@@ -47,28 +48,11 @@ native const class BigInt
   ** Compare based on integer value.
   override Int compare(Obj obj)
 
-  ** Return decimal string representation.
-  override Str toStr()
+  ** The hash for a BigInt is platform dependent.
+  override Int hash()
 
 //////////////////////////////////////////////////////////////////////////
-// Identity
-//////////////////////////////////////////////////////////////////////////
-
-  ** -1, 0, 1 if the BigInt is negative, zero, or positive.
-  Int signum()
-
-  ** Convert the number to an Int.
-  **
-  ** If the value is out-of-range and checked is true, an Err is thrown.
-  ** Otherwise the value is truncated, with possible loss of sign.
-  Int toInt(Bool checked := true)
-
-  ** Returns a byte array containing the two's-complement representation
-  ** of this BigInt.
-  Buf toBuf()
-
-//////////////////////////////////////////////////////////////////////////
-// Methods
+// Operations
 //////////////////////////////////////////////////////////////////////////
 
   ////////// unary //////////
@@ -81,6 +65,46 @@ native const class BigInt
 
   ** Decrement by one.  Shortcut is --a or a--.
   @Operator BigInt decrement()
+
+  ////////// mult //////////
+
+  ** Multiply this with b.  Shortcut is a*b.
+  @Operator BigInt mult(BigInt b)
+
+  ** Multiply this with b.  Shortcut is a*b.
+  @Operator BigInt multInt(Int b)
+
+  ////////// div //////////
+
+  ** Divide this by b.  Shortcut is a/b.
+  @Operator BigInt div(BigInt b)
+
+  ** Divide this by b.  Shortcut is a/b.
+  @Operator BigInt divInt(Int b)
+
+  ////////// mod //////////
+
+  ** Return remainder of this divided by b.  Shortcut is a%b.
+  @Operator BigInt mod(BigInt b)
+
+  ** Return remainder of this divided by b.  Shortcut is a%b.
+  @Operator Int modInt(Int b)
+
+  ////////// plus //////////
+
+  ** Add this with b.  Shortcut is a+b.
+  @Operator BigInt plus(BigInt b)
+
+  ** Add this with b.  Shortcut is a+b.
+  @Operator BigInt plusInt(Int b)
+
+  ////////// minus //////////
+
+  ** Subtract b from this.  Shortcut is a-b.
+  @Operator BigInt minus(BigInt b)
+
+  ** Subtract b from this.  Shortcut is a-b.
+  @Operator BigInt minusInt(Int b)
 
 //////////////////////////////////////////////////////////////////////////
 // Bitwise
@@ -126,5 +150,60 @@ native const class BigInt
   ** similar to Int.shifta, not Int.shiftr.  Sign extension is performed.
   ** Negative values call shiftl instead.
   BigInt shiftr(Int b)
+
+//////////////////////////////////////////////////////////////////////////
+// Math
+//////////////////////////////////////////////////////////////////////////
+
+  ** -1, 0, 1 if the BigInt is negative, zero, or positive.
+  Int signum()
+
+  ** Return the absolute value of this integer.  If this value is
+  ** positive then return this, otherwise return the negation.
+  BigInt abs()
+
+  ** Return the smaller of this and the specified BigInt values.
+  BigInt min(BigInt that)
+
+  ** Return the larger of this and the specified BigInt values.
+  BigInt max(BigInt that)
+
+  ** Return this value raised to the specified power.
+  ** Throw ArgErr if pow is less than zero.
+  BigInt pow(Int pow)
+
+//////////////////////////////////////////////////////////////////////////
+// Conversion
+//////////////////////////////////////////////////////////////////////////
+
+  ** Convert the number to an Int.
+  **
+  ** If the value is out-of-range and checked is true, an Err is thrown.
+  ** Otherwise the value is truncated, with possible loss of sign.
+  Int toInt(Bool checked := true)
+
+  ** Convert the number to an Float.
+  **
+  ** If the value is out-of-range, it will return Float.posInf
+  ** or Float.negInf.  Possible loss of precision is still possible, even
+  ** if the value is finite.
+  Float toFloat()
+
+  ** Convert the number to an Decimal.
+  **
+  ** This simply wraps the BigInt with Decimal with a 0 scale,
+  ** equivilent mathematically to int * 2^0
+  Decimal toDecimal()
+
+  ** Returns a byte array containing the two's-complement representation
+  ** of this BigInt.
+  Buf toBuf()
+
+  ** Return decimal string representation.
+  override Str toStr()
+
+  ** Return string representation in given radix.  If width is non-null,
+  ** then leading zeros are prepended to ensure the specified width.
+  Str toRadix(Int radix, Int? width := null)
 
 }

--- a/src/math/fan/BigInt.fan
+++ b/src/math/fan/BigInt.fan
@@ -16,42 +16,42 @@ native const class BigInt
 // Construction
 //////////////////////////////////////////////////////////////////////////
 
-	static new fromStr(Str s, Int radix := 10, Bool checked := true)
+  static new fromStr(Str s, Int radix := 10, Bool checked := true)
 
-	** Default value is 0.
-	static const BigInt defVal
-	static const BigInt zero
-	static const BigInt one
+  ** Default value is 0.
+  static const BigInt defVal
+  static const BigInt zero
+  static const BigInt one
 
-	new makeInt(Int val)
-	new makeBuf(Buf bytes)
+  new makeInt(Int val)
+  new makeBuf(Buf bytes)
 
-	private new privateMake()
+  private new privateMake()
 
 //////////////////////////////////////////////////////////////////////////
 // Obj
 //////////////////////////////////////////////////////////////////////////
 
-	override Bool equals(Obj? obj)
+  override Bool equals(Obj? obj)
 
-	override Int compare(Obj obj)
+  override Int compare(Obj obj)
 
-	override Str toStr()
+  override Str toStr()
 
 //////////////////////////////////////////////////////////////////////////
 // Identity
 //////////////////////////////////////////////////////////////////////////
 
-	** -1, 0, 1 if the BigInt is negative, zero, or positive.
-	Int signum()
+  ** -1, 0, 1 if the BigInt is negative, zero, or positive.
+  Int signum()
 
-	** Convert the number to an Int.
-	**
-	** If the value is out-of-range and checked is true, an Err is thrown.
-	** Otherwise the value is truncated, with possible loss of sign.
-	Int toInt(Bool checked := true)
+  ** Convert the number to an Int.
+  **
+  ** If the value is out-of-range and checked is true, an Err is thrown.
+  ** Otherwise the value is truncated, with possible loss of sign.
+  Int toInt(Bool checked := true)
 
-	Buf toBuf()
+  Buf toBuf()
 
 //////////////////////////////////////////////////////////////////////////
 // Methods
@@ -59,38 +59,38 @@ native const class BigInt
 
   ////////// unary //////////
 
-	@Operator BigInt negate()
+  @Operator BigInt negate()
 
-	@Operator BigInt increment()
+  @Operator BigInt increment()
 
-	@Operator BigInt decrement()
+  @Operator BigInt decrement()
 
 //////////////////////////////////////////////////////////////////////////
 // Bitwise
 //////////////////////////////////////////////////////////////////////////
 
-	BigInt setBit(Int b)
+  BigInt setBit(Int b)
 
-	BigInt clearBit(Int b)
+  BigInt clearBit(Int b)
 
-	BigInt flipBit(Int b)
+  BigInt flipBit(Int b)
 
-	Bool testBit(Int b)
+  Bool testBit(Int b)
 
-	** Returns the number of bits in the minimal two's-complement
-	** representation of this BigInteger, excluding a sign bit.
-	Int bitLen()
+  ** Returns the number of bits in the minimal two's-complement
+  ** representation of this BigInteger, excluding a sign bit.
+  Int bitLen()
 
-	BigInt not()
+  BigInt not()
 
-	BigInt and(Obj b)
+  BigInt and(Obj b)
 
-	BigInt or(Obj b)
+  BigInt or(Obj b)
 
-	BigInt xor(Obj b)
+  BigInt xor(Obj b)
 
-	BigInt shiftl(Int b)
+  BigInt shiftl(Int b)
 
-	BigInt shftr(Int b)
+  BigInt shftr(Int b)
 
 }

--- a/src/math/fan/BigInt.fan
+++ b/src/math/fan/BigInt.fan
@@ -16,6 +16,9 @@ native const class BigInt
 // Construction
 //////////////////////////////////////////////////////////////////////////
 
+  ** Parse a Str into a BigInt using the specified radix.
+  ** If invalid format and checked is false return null,
+  ** otherwise throw ParseErr.
   static new fromStr(Str s, Int radix := 10, Bool checked := true)
 
   ** Default value is 0.
@@ -23,19 +26,28 @@ native const class BigInt
   static const BigInt zero
   static const BigInt one
 
+  ** Returns a BigInt whose value is equal to that of
+  ** the specified Int. 
   new makeInt(Int val)
+
+  ** Translates a byte array containing the two's-complement binary
+  ** representation of a BigInt into a BigInt.
   new makeBuf(Buf bytes)
 
+  ** Private constructor.
   private new privateMake()
 
 //////////////////////////////////////////////////////////////////////////
 // Obj
 //////////////////////////////////////////////////////////////////////////
 
+  ** Return true if same both represent that same integer value.
   override Bool equals(Obj? obj)
 
+  ** Compare based on integer value.
   override Int compare(Obj obj)
 
+  ** Return decimal string representation.
   override Str toStr()
 
 //////////////////////////////////////////////////////////////////////////
@@ -51,6 +63,8 @@ native const class BigInt
   ** Otherwise the value is truncated, with possible loss of sign.
   Int toInt(Bool checked := true)
 
+  ** Returns a byte array containing the two's-complement representation
+  ** of this BigInt.
   Buf toBuf()
 
 //////////////////////////////////////////////////////////////////////////
@@ -59,38 +73,58 @@ native const class BigInt
 
   ////////// unary //////////
 
+  ** Negative of this.  Shortcut is -a.
   @Operator BigInt negate()
 
+  ** Increment by one.  Shortcut is ++a or a++.
   @Operator BigInt increment()
 
+  ** Decrement by one.  Shortcut is --a or a--.
   @Operator BigInt decrement()
 
 //////////////////////////////////////////////////////////////////////////
 // Bitwise
 //////////////////////////////////////////////////////////////////////////
 
+  ** Set the given bit to 1.
+  ** Equivalent to this.or(1.shiftl(b)).
   BigInt setBit(Int b)
 
+  ** Set the given bit to 0.
+  ** Equivalent to this.and(1.shiftl(b).not).
   BigInt clearBit(Int b)
 
+  ** Flip the given bit between 0 and 1.
+  ** Equivalent to this.xor(1.shiftl(b)).
   BigInt flipBit(Int b)
 
+  ** Return true if given bit is 1.
+  ** Equivalent to this.and(1.shiftl(b)) != 0.
   Bool testBit(Int b)
 
   ** Returns the number of bits in the minimal two's-complement
   ** representation of this BigInteger, excluding a sign bit.
   Int bitLen()
 
+  ** Bitwise not/inverse of this.
   BigInt not()
 
+  ** Bitwise-and of this and b.
   BigInt and(Obj b)
 
+  ** Bitwise-or of this and b.
   BigInt or(Obj b)
 
+  ** Bitwise-exclusive-or of this and b.
   BigInt xor(Obj b)
 
+  ** Bitwise left shift of this by b.
+  ** Negative values call shiftr instead.
   BigInt shiftl(Int b)
 
-  BigInt shftr(Int b)
+  ** Bitwise arithmetic right-shift of this by b.  Note that this is
+  ** similar to Int.shifta, not Int.shiftr.  Sign extension is performed.
+  ** Negative values call shiftl instead.
+  BigInt shiftr(Int b)
 
 }

--- a/src/math/java/BigInt.java
+++ b/src/math/java/BigInt.java
@@ -8,6 +8,7 @@
 
 package fan.math;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import fan.sys.*;
 
@@ -56,29 +57,6 @@ public final class BigInt extends FanObj
   private static final Type typeof = Type.find("math::BigInt");
 
 //////////////////////////////////////////////////////////////////////////
-// Identity
-//////////////////////////////////////////////////////////////////////////
-
-  public static final BigInt defVal = new BigInt(BigInteger.ZERO);
-  public static final BigInt zero   = defVal;
-  public static final BigInt one    = new BigInt(BigInteger.ONE);
-
-  public long signum() { return self.signum(); }
-
-  public long toInt() { return toInt(true); }
-  public long toInt(final boolean checked)
-  {
-    // longValueExact() is 1.8 only, but preferable
-    return self.longValue();
-//    return checked ? self.longValueExact() : self.longValue();
-  }
-
-  public Buf toBuf()
-  {
-    return new MemBuf(self.toByteArray());
-  }
-
-//////////////////////////////////////////////////////////////////////////
 // Operators
 //////////////////////////////////////////////////////////////////////////
 
@@ -87,6 +65,21 @@ public final class BigInt extends FanObj
   public BigInt increment() { return new BigInt(self.add(BigInteger.ONE)); }
 
   public BigInt decrement() { return new BigInt(self.subtract(BigInteger.ONE)); }
+
+  public BigInt mult(BigInt x) { return new BigInt(self.multiply(x.self)); }
+  public BigInt multInt(long x) { return new BigInt(self.multiply(BigInteger.valueOf(x))); }
+
+  public BigInt div(BigInt x) { return new BigInt(self.divide(x.self)); }
+  public BigInt divInt(long x) { return new BigInt(self.divide(BigInteger.valueOf(x))); }
+
+  public BigInt mod(BigInt x) { return new BigInt(self.remainder(x.self)); }
+  public long modInt(long x) { return self.remainder(BigInteger.valueOf(x)).longValue(); }
+
+  public BigInt plus(BigInt x) { return new BigInt(self.add(x.self)); }
+  public BigInt plusInt(long x) { return new BigInt(self.add(BigInteger.valueOf(x))); }
+
+  public BigInt minus(BigInt x) { return new BigInt(self.subtract(x.self)); }
+  public BigInt minusInt(long x) { return new BigInt(self.subtract(BigInteger.valueOf(x))); }
 
 //////////////////////////////////////////////////////////////////////////
 // Bitwise
@@ -125,9 +118,59 @@ public final class BigInt extends FanObj
 // Math
 //////////////////////////////////////////////////////////////////////////
 
-  public BigInt abs()
+  public long signum() { return self.signum(); }
+
+  public BigInt abs() { return new BigInt(self.abs()); }
+
+  public BigInt min(BigInt x) { return new BigInt(self.min(x.self)); }
+
+  public BigInt max(BigInt x) { return new BigInt(self.max(x.self)); }
+
+  public BigInt pow(long x)
   {
-    return new BigInt(self.abs());
+    int asInt = x > (long)Integer.MAX_VALUE
+      ? Integer.MAX_VALUE
+      : (x < (long)Integer.MIN_VALUE
+        ? Integer.MIN_VALUE
+        : (int)x);
+    return new BigInt(self.pow(asInt));
+  }
+
+//////////////////////////////////////////////////////////////////////////
+// Conversion
+//////////////////////////////////////////////////////////////////////////
+
+  public long toInt() { return toInt(true); }
+  public long toInt(final boolean checked)
+  {
+    // longValueExact() is 1.8 only, but preferable
+    return checked ? self.longValueExact() : self.longValue();
+  }
+
+  public double toFloat() { return self.floatValue(); }
+
+  public BigDecimal toDecimal() { return new BigDecimal(self); }
+
+  public Buf toBuf()
+  {
+    return new MemBuf(self.toByteArray());
+  }
+
+  public String toRadix(long radix) { return toRadix(radix, null); }
+  public String toRadix(long radix, Long width)
+  {
+    return pad(self.toString((int)radix), width);
+  }
+
+  // Taken from FanInt.java
+  private static String pad(String s, Long width)
+  {
+    if (width == null || s.length() >= width.intValue()) return s;
+    StringBuilder sb = new StringBuilder(width.intValue());
+    int zeros = width.intValue() - s.length();
+    for (int i=0; i<zeros; ++i) sb.append('0');
+    sb.append(s);
+    return sb.toString();
   }
 
 //////////////////////////////////////////////////////////////////////////
@@ -163,6 +206,10 @@ public final class BigInt extends FanObj
 //////////////////////////////////////////////////////////////////////////
 // Fields
 //////////////////////////////////////////////////////////////////////////
+
+  public static final BigInt defVal = new BigInt(BigInteger.ZERO);
+  public static final BigInt zero   = defVal;
+  public static final BigInt one    = new BigInt(BigInteger.ONE);
 
   private BigInteger self;
 

--- a/src/math/java/BigInt.java
+++ b/src/math/java/BigInt.java
@@ -18,35 +18,35 @@ public final class BigInt extends FanObj
 // Construction
 //////////////////////////////////////////////////////////////////////////
 
-	public static BigInt fromStr(final String s) { return fromStr(s, 10); }
-	public static BigInt fromStr(final String s, final long radix) { return fromStr(s, radix, true); }
-	public static BigInt fromStr(final String s, final long radix, final boolean checked)
-	{
-		try
-		{
-			return new BigInt(new BigInteger(s, (int)radix));
-		}
-		catch (NumberFormatException e)
-		{
-			if (!checked) return null;
-			throw ParseErr.make("BigInt", s);
-		}
-	}
+  public static BigInt fromStr(final String s) { return fromStr(s, 10); }
+  public static BigInt fromStr(final String s, final long radix) { return fromStr(s, radix, true); }
+  public static BigInt fromStr(final String s, final long radix, final boolean checked)
+  {
+    try
+    {
+      return new BigInt(new BigInteger(s, (int)radix));
+    }
+    catch (NumberFormatException e)
+    {
+      if (!checked) return null;
+      throw ParseErr.make("BigInt", s);
+    }
+  }
 
-	public static BigInt makeInt(final long val)
-	{
-		return new BigInt(BigInteger.valueOf(val));
-	}
+  public static BigInt makeInt(final long val)
+  {
+    return new BigInt(BigInteger.valueOf(val));
+  }
 
-	public static BigInt makeBuf(Buf bytes)
-	{
-		return new BigInt(new BigInteger(bytes.safeArray()));
-	}
+  public static BigInt makeBuf(Buf bytes)
+  {
+    return new BigInt(new BigInteger(bytes.safeArray()));
+  }
 
-	public BigInt(BigInteger val)
-	{
-		this.self = val;
-	}
+  public BigInt(BigInteger val)
+  {
+    this.self = val;
+  }
 
 //////////////////////////////////////////////////////////////////////////
 // Type
@@ -59,24 +59,24 @@ public final class BigInt extends FanObj
 // Identity
 //////////////////////////////////////////////////////////////////////////
 
- 	public static final BigInt defVal = new BigInt(BigInteger.ZERO);
- 	public static final BigInt zero   = defVal;
- 	public static final BigInt one    = new BigInt(BigInteger.ONE);
+  public static final BigInt defVal = new BigInt(BigInteger.ZERO);
+  public static final BigInt zero   = defVal;
+  public static final BigInt one    = new BigInt(BigInteger.ONE);
 
-	public long signum() { return self.signum(); }
+  public long signum() { return self.signum(); }
 
-	public long toInt() { return toInt(true); }
-	public long toInt(final boolean checked)
-	{
-		// longValueExact() is 1.8 only, but preferable
-		return self.longValue();
-//		return checked ? self.longValueExact() : self.longValue();
-	}
+  public long toInt() { return toInt(true); }
+  public long toInt(final boolean checked)
+  {
+    // longValueExact() is 1.8 only, but preferable
+    return self.longValue();
+//    return checked ? self.longValueExact() : self.longValue();
+  }
 
-	public Buf toBuf()
-	{
-		return new MemBuf(self.toByteArray());
-	}
+  public Buf toBuf()
+  {
+    return new MemBuf(self.toByteArray());
+  }
 
 //////////////////////////////////////////////////////////////////////////
 // Operators
@@ -86,40 +86,40 @@ public final class BigInt extends FanObj
 
   public BigInt increment() { return new BigInt(self.add(BigInteger.ONE)); }
 
- 	public BigInt decrement() { return new BigInt(self.subtract(BigInteger.ONE)); }
+  public BigInt decrement() { return new BigInt(self.subtract(BigInteger.ONE)); }
 
 //////////////////////////////////////////////////////////////////////////
 // Bitwise
 //////////////////////////////////////////////////////////////////////////
 
- 	public BigInt setBit(final long bit) { return new BigInt(self.setBit((int)bit)); }
+  public BigInt setBit(final long bit) { return new BigInt(self.setBit((int)bit)); }
 
- 	public BigInt clearBit(final long bit) { return new BigInt(self.clearBit((int)bit)); }
+  public BigInt clearBit(final long bit) { return new BigInt(self.clearBit((int)bit)); }
 
- 	public BigInt flipBit(final long bit) { return new BigInt(self.flipBit((int)bit)); }
+  public BigInt flipBit(final long bit) { return new BigInt(self.flipBit((int)bit)); }
 
- 	public boolean testBit(final long bit) { return self.testBit((int)bit); }
+  public boolean testBit(final long bit) { return self.testBit((int)bit); }
 
- 	public long bitLen() { return self.bitLength(); }
+  public long bitLen() { return self.bitLength(); }
 
- 	public BigInt not() { return new BigInt(self.not()); }
+  public BigInt not() { return new BigInt(self.not()); }
 
- 	public BigInt and(Object b) { return new BigInt(self.and(bi(b))); }
+  public BigInt and(Object b) { return new BigInt(self.and(bi(b))); }
 
- 	public BigInt or(Object b) { return new BigInt(self.or(bi(b))); }
+  public BigInt or(Object b) { return new BigInt(self.or(bi(b))); }
 
- 	public BigInt xor(Object b) { return new BigInt(self.xor(bi(b))); }
+  public BigInt xor(Object b) { return new BigInt(self.xor(bi(b))); }
 
- 	public BigInt shiftl(long b) { return new BigInt(self.shiftLeft((int)b)); }
+  public BigInt shiftl(long b) { return new BigInt(self.shiftLeft((int)b)); }
 
- 	public BigInt shiftr(long b) { return new BigInt(self.shiftRight((int)b)); }
+  public BigInt shiftr(long b) { return new BigInt(self.shiftRight((int)b)); }
 
- 	private static BigInteger bi(Object obj)
- 	{
- 		if (obj instanceof BigInt) return ((BigInt)obj).self;
- 		if (obj instanceof Long) return BigInteger.valueOf((Long)obj);
- 		throw ArgErr.make("Not a BigInt or Int: " + obj.getClass());
- 	}
+  private static BigInteger bi(Object obj)
+  {
+    if (obj instanceof BigInt) return ((BigInt)obj).self;
+    if (obj instanceof Long) return BigInteger.valueOf((Long)obj);
+    throw ArgErr.make("Not a BigInt or Int: " + obj.getClass());
+  }
 
 //////////////////////////////////////////////////////////////////////////
 // Math
@@ -127,7 +127,7 @@ public final class BigInt extends FanObj
 
   public BigInt abs()
   {
-  	return new BigInt(self.abs());
+    return new BigInt(self.abs());
   }
 
 //////////////////////////////////////////////////////////////////////////
@@ -136,28 +136,28 @@ public final class BigInt extends FanObj
 
   public boolean equals(Object obj)
   {
-  	if (obj instanceof BigInt)
-  	{
-  		BigInt that = (BigInt)obj;
-  		return self.equals(that.self);
-  	}
-  	return false;
+    if (obj instanceof BigInt)
+    {
+      BigInt that = (BigInt)obj;
+      return self.equals(that.self);
+    }
+    return false;
   }
 
   public long compare(Object obj)
   {
-  	BigInt that = (BigInt)obj;
-  	return self.compareTo(that.self);
+    BigInt that = (BigInt)obj;
+    return self.compareTo(that.self);
   }
 
   public long hash()
   {
-  	return self.hashCode();
+    return self.hashCode();
   }
 
   public String toStr()
   {
-  	return self.toString();
+    return self.toString();
   }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/sys/fan/Int.fan
+++ b/src/sys/fan/Int.fan
@@ -415,8 +415,8 @@ const final class Int : Num
   ** then leading zeros are prepended to ensure the specified width.
   **
   ** Examples:
-  **   255.toRadix(8)    =>  "ff"
-  **   255.toRadix(8, 3) =>  "00ff"
+  **   255.toRadix(8)    =>  "377"
+  **   255.toRadix(8, 5) =>  "00377"
   **
   Str toRadix(Int radix, Int? width := null)
 


### PR DESCRIPTION
Split this into two commits:

1. A clean-up commit which has the following:
* Added documentation for all the existing `math::BigInt` methods (mostly a combination from Int and java's BigInteger + a bit of my own comments).
* `sys::Int.toRadix`'s example was inaccurate 🙂.  Fixed to be a better example.
* I noticed the files were using both using tabs and spaces together for indentation. 
 I converted them all to be consistent.  I noticed the pod was mostly using tabs, so I made the few random spaces into tabs to keep it clean.  If you want the whole pod converted to spaces (which both I prefer as well as I notice most of Fantom is written in), I can amend this with that change.
* `math::BigInt.shiftr` was misspelled "shftr".
2. The primary commit which added a bunch of new methods to `math::BigInt` like all the arithmetic operator methods and a few other common ones (toRadix, etc).