### PR TITLE
dom: Added missing 'self' parameters to Java Peer methods

### DIFF
--- a/src/dom/fan/Event.fan
+++ b/src/dom/fan/Event.fan
@@ -23,13 +23,6 @@ using graphics
 **   "click"       Fired when a mouse button is pressed and released on a
 **                 single element.
 **
-**   "mousedown"   Fired when a mouse button is pressed on an element.
-**
-**   "mouseup"     Fired when a mouse button is released over an element.
-**
-**   "click"       Fired when a mouse button is pressed and released on a
-**                 single element.
-**
 **   "dblclick"    Fired when a mouse button is clicked twice on a single element.
 **
 **   "mousemove"   Fired when a mouse is moved while over an element.

--- a/src/dom/java/DomPeerFactory.java
+++ b/src/dom/java/DomPeerFactory.java
@@ -78,7 +78,7 @@ public class DomPeerFactory
     throw UnsupportedErr.make("elem.fromNative");
   }
 
-  public Event eventFromNative(Object elem)
+  public Event eventFromNative(Object event)
   {
     throw UnsupportedErr.make("event.fromNative");
   }

--- a/src/dom/java/ElemPeer.java
+++ b/src/dom/java/ElemPeer.java
@@ -66,8 +66,8 @@ public class ElemPeer
   public String html(Elem self) { throw err(); }
   public void html(Elem self, String html) { throw err(); }
 
-  public boolean enabled(Elem self) { return enabled; }
-  public void enabled(Elem self, boolean v) { this.enabled = v; }
+  public Boolean enabled(Elem self) { return enabled; }
+  public void enabled(Elem self, Boolean v) { this.enabled = v; }
 
 //////////////////////////////////////////////////////////////////////////
 // Attributes

--- a/src/dom/java/HttpReqPeer.java
+++ b/src/dom/java/HttpReqPeer.java
@@ -17,8 +17,8 @@ public class HttpReqPeer
     return DomPeerFactory.factory().makeHttpReq(fan);
   }
 
-  public void   send      (String method, Object content, Func c) { throw err(); }
-  public String encodeForm(Map form)                              { throw err(); }
+  public void   send      (HttpReq self, String method, Object content, Func c) { throw err(); }
+  public String encodeForm(HttpReq self, Map form)                              { throw err(); }
 
   private static Err err() { return UnsupportedErr.make(); }
 }

--- a/src/dom/java/StylePeer.java
+++ b/src/dom/java/StylePeer.java
@@ -67,7 +67,7 @@ public class StylePeer
 
   Object computed(Style self, String name) { throw err(); }
 
-  Object effective(String name) { throw err(); }
+  Object effective(Style self, String name) { throw err(); }
 
   public Object get(Style self, String name)
   {

--- a/src/dom/java/WinPeer.java
+++ b/src/dom/java/WinPeer.java
@@ -48,8 +48,8 @@ public class WinPeer
   public Uri     uri               (Win self)                                           { throw err(); }
   public void    hyperlink         (Win self, Uri uri)                                  { throw err(); }
   public void    reload            (Win self, boolean force)                            { throw err(); }
-  public void    clipboardReadText (Func f)                                             { throw err(); }
-  public void    clipboardWriteText(String text)                                        { throw err(); }
+  public void    clipboardReadText (Win self, Func f)                                   { throw err(); }
+  public void    clipboardWriteText(Win self, String text)                              { throw err(); }
   public void    hisBack           (Win self)                                           { throw err(); }
   public void    hisForward        (Win self)                                           { throw err(); }
   public void    hisPushState      (Win self, String title, Uri uri, Map map)           { throw err(); }


### PR DESCRIPTION
 - Added missing 'self' parameters to a couple of Java Peer methods
 - Elem.enabled should map to a Java Wrapper class not a primitive 'cos it's nullable (this has always been wrong)
 - Fixed the odd typo
