### PR TITLE
Docker CI fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+dockerfile

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,11 @@
 name: Create and publish a Docker image to GitHub Packages
 
 on:
-  push: { branches: [ master ] }
+  push: 
+    branches: 
+      - master
+    tags:
+      - v*
 
 env:
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,35 +4,34 @@ on:
   push: { branches: [ master ] }
 
 env:
-  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push-image:
+  build-and-publish-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/dockerfile
+++ b/dockerfile
@@ -11,8 +11,7 @@ ARG JDK_VERSION=17
 FROM eclipse-temurin:$JDK_VERSION as bootstrap
 
 ARG FAN_DL_URL=https://github.com/fantom-lang/fantom/releases/download
-# SWT 4.16 was the last one with JDK 8 support
-ARG SWT_DL_URL=https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.16-202006040540/swt-4.16-gtk-linux-x86_64.zip
+ARG SWT_DL_URL=https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.27-202303020300/swt-4.27-gtk-linux-x86_64.zip&mirror_id=1
 
 # These define the `rel` Fantom version.
 ARG REL_VERSION=fantom-1.0.77

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,12 @@
-ARG JDK_VERSION=17
+# USAGE
+# docker build -t fantom .
+#
+# The following build args are accepted, with documentation:
+# - JDK_VERSION: The version of the JDK to use. Defaults to 17.
+# - SWT_DL_URL: The URL to download the SWT jar from. Defaults to 4.27. Be sure that this is compatible with your JDK version.
+# - REL_VERSION: The version name of Fantom to use to bootstrap. Defaults to fantom-1.0.77.
+# - REL_TAG: The tag of Fantom to use to bootstrap. Be sure that matches REL_VERSION. Defaults to v1.0.77.
+
 
 # ================================
 # Bootstrap image
@@ -8,9 +16,10 @@ ARG JDK_VERSION=17
 # It mirrors the Bootstrap.fan script, but does not use it (since we want to use the 
 # local fantom, not one pulled via git).
 
+ARG JDK_VERSION=17
+
 FROM eclipse-temurin:$JDK_VERSION as bootstrap
 
-ARG FAN_DL_URL=https://github.com/fantom-lang/fantom/releases/download
 ARG SWT_DL_URL=https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.27-202303020300/swt-4.27-gtk-linux-x86_64.zip&mirror_id=1
 
 # These define the `rel` Fantom version.
@@ -20,7 +29,7 @@ ARG REL_TAG=v1.0.77
 WORKDIR /work
 
 RUN set -e; \
-    FAN_BIN_URL="$FAN_DL_URL/$REL_TAG/$REL_VERSION.zip" \
+    FAN_BIN_URL="https://github.com/fantom-lang/fantom/releases/download/$REL_TAG/$REL_VERSION.zip" \
     # Install curl
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -q update && apt-get -q install -y curl unzip && rm -rf /var/lib/apt/lists/* \

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,18 @@ Installers are also available for macOS and Windows:
   * macOS: `brew install fantom`
   * Windows: [installer](https://github.com/Fantom-Factory/fantomWindowsInstaller/releases)
 
+### Docker
+
+This repo vends a docker image that can be downloaded and run locally using:
+```bash
+docker run -it ghcr.io/fantom-lang/fantom:latest bash
+```
+
+It can be used in other dockerfiles using the `FROM` command:
+```dockerfile
+FROM ghcr.io/fantom-lang/fantom:latest AS build
+```
+
 ## Community
 
 We are most active on the [Forum](http://fantom.org/forum/topic), but also hang out on [Slack](https://join.slack.com/t/fantom-lang/shared_invite/zt-3se21er9-Tm~L2lpYel6jcqYKPcdkBg). 


### PR DESCRIPTION
This fixes the following issues with the Docker image generation:

1. Docker images were published only on commits to `master`, and not on git release tags. This PR ensures that images are automatically built on any `v*` git tag, applying the `vX.X.X` and `latest` docker tags. 
2. Docker images were built on Java 8. This bumps them to Java 17, and makes the version configurable using a Docker build arg.
3. The docker CI was using commit-hash dependencies. This changes them to the mainline versions.

It also fixes little inconsistencies and adds some documentation.