### PR TITLE
compiler: Let unknownVar throw CompilerErr with more informative context

### DIFF
--- a/src/compiler/fan/assembler/CodeAsm.fan
+++ b/src/compiler/fan/assembler/CodeAsm.fan
@@ -670,7 +670,7 @@ class CodeAsm : CompilerSupport
       case ExprId.ternary:         ternary(expr)
       case ExprId.staticTarget:    return
       case ExprId.throwExpr:       throwOp(((ThrowExpr)expr).exception)
-      default:                     throw Err(expr.id.toStr)
+      default:                     throw err("${expr.id} - ${expr.toStr}", expr.loc)
     }
   }
 


### PR DESCRIPTION
Unresolved `unknownVar` exprs would throw an `Err` with an unhelpful msg.

With this change, a more useful `CompilerErr` is reported, with a location, and with a lot more informative context in the msg.