### PR TITLE
Updated TS decl writer & dom pod, mostly to align with the swizzle change

### DIFF
--- a/src/dom/es/DocPeer.js
+++ b/src/dom/es/DocPeer.js
@@ -45,6 +45,22 @@ class DocPeer extends sys.Obj {
     return ElemPeer.wrap(elem);
   }
 
+  elemFromPos(self, p)
+  {
+    const elem = this.doc.elementFromPoint(p.x(), p.y());
+    if (elem == null) return null;
+    return ElemPeer.wrap(elem);
+  }
+
+  elemsFromPos(self, p)
+  {
+    const list  = sys.List.make(Elem.type$);
+    const elems = this.doc.elementsFromPoint(p.x(), p.y());
+    for (let i=0; i<elems.length; i++)
+      list.add(ElemPeer.wrap(elems[i]));
+    return list;
+  }
+
   createElem(self, tagName, attribs, ns)
   {
     const elem = ns

--- a/src/dom/es/EventPeer.js
+++ b/src/dom/es/EventPeer.js
@@ -45,6 +45,17 @@ class EventPeer extends sys.Obj {
     return this.#target;
   }
 
+  #relatedTarget;
+  relatedTarget(self)
+  {
+    if (this.#relatedTarget === undefined)
+    {
+      const rt = this.event.relatedTarget;
+      this.#relatedTarget = rt == null ? null : ElemPeer.wrap(rt);
+    }
+    return this.#relatedTarget;
+  }
+
   #pagePos;
   pagePos(self)
   {

--- a/src/dom/es/WeakMapPeer.js
+++ b/src/dom/es/WeakMapPeer.js
@@ -13,6 +13,6 @@ class WeakMapPeer extends sys.Obj {
   has(self, key)      { return this.map.has(key); }
   get(self, key)      { return this.map.get(key); }
   set(self, key, val) { this.map.set(key, val); return self; }
-  delete$(self, key)  { return this.map.delete$(key); }
+  delete(self, key)   { return this.map.delete(key); }
 
 }

--- a/src/nodeJs/fan/ts/CompileTsPlugin.fan
+++ b/src/nodeJs/fan/ts/CompileTsPlugin.fan
@@ -53,7 +53,6 @@ class CompileTsPlugin : CompilerStep
       // they have the @Js facet or not
       // if (!type.hasFacet(jsFacet)) return
       if (type.isInternal) return
-      if (type.signature == "sys::Func") return
 
       setupDoc(pod.name, type.name)
 
@@ -119,6 +118,7 @@ class CompileTsPlugin : CompilerStep
         isStatic := method.isStatic || method.isCtor || pmap.containsKey(type.signature)
         staticStr := isStatic ? "static " : ""
         name := JsNode.methodToJs(method.name)
+        if (type.signature == "sys::Func") name += "<R>"
 
         inputList := method.params.map |CParam p->Str| {
           paramName := JsNode.pickleName(p.name, deps)
@@ -170,7 +170,7 @@ class CompileTsPlugin : CompilerStep
   private Str getJsType(CType type, CPod thisPod, CType? thisType := null)
   {
     // Built-in type
-    if (pmap.containsKey(type.signature))
+    if (pmap.containsKey(type.signature) && !type.isFunc)
       return pmap[type.signature]
 
     // Nullable type
@@ -187,6 +187,8 @@ class CompileTsPlugin : CompilerStep
       {
         case "L": return "List<V>"
         case "M": return "Map<K,V>"
+        case "R": return "R"
+        default:  return "unknown"
       }
     
     // List/map types
@@ -268,12 +270,12 @@ class CompileTsPlugin : CompilerStep
                     static is(obj: any, type: Type): boolean
                     static as(obj: any, type: Type): any
                     static coerce(obj: any, type: Type): any
-                    static typeof\$(obj: any): Type
+                    static typeof(obj: any): Type
                     static trap(obj: any, name: string, args: List<JsObj | null> | null): JsObj | null
                     static doTrap(obj: any, name: string, args: List<JsObj | null> | null, type: Type): JsObj | null
                     static isImmutable(obj: any): boolean
                     static toImmutable(obj: any): JsObj | null
-                    static with\$<T>(self: T, f: (() => T)): T
+                    static with<T>(self: T, f: ((it: T) => void)): T
                     static toStr(obj: any): string
                     static echo(obj: any): void
                   }
@@ -288,7 +290,8 @@ class CompileTsPlugin : CompilerStep
     "sys::Int":     "number",
     "sys::Num":     "number",
     "sys::Str":     "string",
-    "sys::Void":    "void"
+    "sys::Void":    "void",
+    "sys::Func":    "(...args: any[]) => R"
   ]
 
 }

--- a/src/nodeJs/fan/ts/CompileTsPlugin.fan
+++ b/src/nodeJs/fan/ts/CompileTsPlugin.fan
@@ -35,11 +35,10 @@ class CompileTsPlugin : CompilerStep
   {
     buf := Buf()
     out = buf.out
+    docWriter = TsDocWriter(out)
 
     // Write dependencies
     deps := pod.depends.map |CDepend dep->Str| { dep.name }
-    docWriter = TsDocWriter(out, deps)
-
     deps.each |dep|
     {
       out.print("import * as ${dep} from './${dep}.js';\n")
@@ -93,7 +92,7 @@ class CompileTsPlugin : CompilerStep
       }
       fields.each |field|
       {
-        name := JsNode.pickleName(field.name, deps)
+        name := JsNode.methodToJs(field.name)
         staticStr := field.isStatic ? "static " : ""
         typeStr := getJsType(field.fieldType, pod, field.isStatic ? type : null)
 
@@ -119,7 +118,7 @@ class CompileTsPlugin : CompilerStep
       {
         isStatic := method.isStatic || method.isCtor || pmap.containsKey(type.signature)
         staticStr := isStatic ? "static " : ""
-        name := JsNode.pickleName(method.name, deps)
+        name := JsNode.methodToJs(method.name)
 
         inputList := method.params.map |CParam p->Str| {
           paramName := JsNode.pickleName(p.name, deps)

--- a/src/nodeJs/fan/ts/TsDocWriter.fan
+++ b/src/nodeJs/fan/ts/TsDocWriter.fan
@@ -22,7 +22,6 @@ class TsDocWriter : DocWriter
   Str type := ""
 
   private OutStream out
-  private Str[] deps
 
   private Bool started
   private ListIndex[] listIndexes := [,]
@@ -32,10 +31,9 @@ class TsDocWriter : DocWriter
   private Int lineWidth := 0
   private const Int maxWidth := 60
 
-  new make(OutStream out, Str[] deps)
+  new make(OutStream out)
   {
     this.out = out
-    this.deps = deps
   }
 
   **
@@ -264,7 +262,7 @@ class TsDocWriter : DocWriter
 
       if (Slot.find("$p::${t}.$s", false) != null)
       {
-        s = JsNode.pickleName(s, deps)
+        s = JsNode.methodToJs(s)
         if (p != pod)       link.uri = "${p}.${t}.$s"
         else if (t != type) link.uri = "${t}.$s"
         else                link.uri = s


### PR DESCRIPTION
In full:
- Method names are no longer swizzled in declaration files
- The Func class declaration matches the implementation, with static methods
- Removed extra $ in ObjUtil declaration file & dom's WeakMap
- Added ES implementation of dom methods that were recently added in JS (elemFromPos, elemsFromPos, relatedTarget)