### PR TITLE
crypto/cryptoJava: Enhance decode to support list of Jwk

### DIFF
--- a/src/crypto/fan/Crypto.fan
+++ b/src/crypto/fan/Crypto.fan
@@ -132,7 +132,7 @@ const mixin Crypto
   **
   abstract Obj? loadPem(InStream in, Str algorithm := "RSA")
 
-  ** Load a JSON Web Key (JWK[`Jwk`]) from a Map. 
+  ** Load a JSON Web Key (`Jwk`) from a Map.
   **
   ** Throws an error if unable to determine the JWK type.
   **
@@ -145,7 +145,7 @@ const mixin Crypto
   **
   ** Import JSON Web Key Set from a Uri
   **
-  ** jwks := Crypto.cur.loadJwksForUri(`https://example.com/jwks.json`)
+  **   jwks := Crypto.cur.loadJwksForUri(`https://example.com/jwks.json`)
   **
   abstract Jwk[] loadJwksForUri(Uri uri, Int maxKeys := 10)
 }

--- a/src/cryptoJava/fan/JJwk.fan
+++ b/src/cryptoJava/fan/JJwk.fan
@@ -100,7 +100,7 @@ const class JJwk : Jwk
     keysList := jwks["keys"] as List
     if (keysList == null) throw Err("Invalid JSON Web Key Set")
     if (keysList.size > maxJwKeys) { keysList = keysList.getRange(0..maxJwKeys-1) }
-    jwkList := [,]
+    Jwk[] jwkList := Jwk[,]
     keysList.each |k| { jwkList = jwkList.add(JJwk(k)) }
     return jwkList
   }


### PR DESCRIPTION
The decode public API can now accept Jwk[], which is convenient for instances where multiple signing keys are used.

Added a Jwt toStr override for convenience.

When decoding, DateTime claims will be stored in Timezone.utc.