### PR TITLE
sql: add support for Postgres text[] and '@>' operator

### DIFF
--- a/src/sql/java/StatementPeer.java
+++ b/src/sql/java/StatementPeer.java
@@ -455,7 +455,15 @@ public class StatementPeer
       while (current != len)
       {
         int ch = sql.charAt(current);
-        if (ch == '@') { mode = MODE_PARAM; break; }
+        if (ch == '@') {
+          // @> is the 'penguin operator' in Postgres, which we do
+          // not want to treat as a parameter.
+          boolean isPenguin = (current < len && sql.charAt(current+1) == '>');
+          if (!isPenguin)
+          {
+            mode = MODE_PARAM; break;
+          }
+        }
         if (ch == '\'') { mode = MODE_QUOTE; break; }
 
         current++;


### PR DESCRIPTION
This pull request improves support for Postgres in the sql pod.

- The Postgres `text[]` field type is now supported by the Fantom `Str[]` type. 
- The Postgres `@>` containment operator no longer generates an error when parsing SQL.

For example, if we have a table defined like this:

```
    create table foo (
      id text primary key,
      bar text[] not null
    );
    create index foo_bar on foo using gin (bar);
```

Then the following test suite snippet demonstrates how these new features work:

```
    insert := conn.sql(
      "insert into foo (id, bar) values (@id, @bar)").prepare
    insert.execute([
      "id":"abc",
      "bar":["x", "y", "z"]
    ])

    filter := conn.sql(
      "select * from foo where (foo.bar @> @bar::text[])").prepare
    rows = filter.query(["bar":"{\"x\"}"])
    verifyEq(rows.size, 1)
    f = rows[0]
    verifyEq(f->id, "abc")
    verifyEq(f->bar, ["x", "y", "z"])
```


