### PR TITLE
Various improvements to the sql pod

### DIFF
--- a/src/sql/fan/SqlConn.fan
+++ b/src/sql/fan/SqlConn.fan
@@ -34,6 +34,9 @@ mixin SqlConn
   ** an exception.  Return true if the connection was closed
   ** successfully or 'false' if closed abnormally.
   **
+  ** Do not close connections that were created by SqlConnPool.  The pool
+  ** handles that for you.
+  **
   abstract Bool close()
 
   **
@@ -42,7 +45,7 @@ mixin SqlConn
   abstract Bool isClosed()
 
   **
-  ** User data stash for adding cached data to this connection
+  ** User data stash for adding cached data to this connection.
   **
   abstract Str:Obj? stash()
 

--- a/src/sql/fan/SqlConnPool.fan
+++ b/src/sql/fan/SqlConnPool.fan
@@ -33,6 +33,18 @@ const class SqlConnPool
   ** actor must call checkLinger periodically to close idle connetions.
   const Duration linger := 5min
 
+  ** onOpen is invoked just after a connection is opened by the pool.
+  ** This method can be used to set up any state needed by the connection, e.g.
+  ** by setting autoCommit, or by adding resources like prepared Statements
+  ** to the connection's stash.
+  protected virtual Void onOpen(SqlConn c) {}
+
+  ** onClose is invoked just before a connection is closed by the pool.
+  ** This method can be used to clean up any state owned by the connection,
+  ** e.g. by closing prepared Statements that are stored in the
+  ** connection's stash.
+  protected virtual Void onClose(SqlConn c) {}
+
   ** Logger
   const Log log := Log.get("sqlPool")
 

--- a/src/sql/fan/SqlConnPool.fan
+++ b/src/sql/fan/SqlConnPool.fan
@@ -33,15 +33,14 @@ const class SqlConnPool
   ** actor must call checkLinger periodically to close idle connetions.
   const Duration linger := 5min
 
-  ** onOpen is invoked just after a connection is opened by the pool.
-  ** This method can be used to set up any state needed by the connection, e.g.
-  ** by setting autoCommit, or by adding resources like prepared Statements
-  ** to the connection's stash.
+  ** onOpen is invoked just after a connection is opened by the pool. This
+  ** method can be used to modify the newly opened connection, for example by
+  ** turning off autoCommit.
   protected virtual Void onOpen(SqlConn c) {}
 
   ** onClose is invoked just before a connection is closed by the pool.
   ** This method can be used to clean up any state owned by the connection,
-  ** e.g. by closing prepared Statements that are stored in the
+  ** for example by closing prepared Statements that are stored in the
   ** connection's stash.
   protected virtual Void onClose(SqlConn c) {}
 

--- a/src/sql/fan/Statement.fan
+++ b/src/sql/fan/Statement.fan
@@ -41,10 +41,17 @@ class Statement
 
   **
   ** Execute the statement.  For each row in the result, invoke
-  ** the specified function 'each'.  The 'Obj' passed to the
-  ** 'each' function will be of type 'Row'.
+  ** the specified function 'eachFunc'.
   **
   native Void queryEach([Str:Obj]? params, |Row row| eachFunc)
+
+  **
+  ** Execute the statement.  For each row in the result, invoke the specified
+  ** function 'eachFunc'. If the function returns non-null, then break the
+  ** iteration and return the resulting object.  Return null if the function
+  ** returns null for every item.
+  **
+  native Obj? queryEachWhile([Str:Obj]? params, |Row row->Obj?| eachFunc)
 
   **
   ** Execute a SQL statement and if applicable return a result:

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -156,11 +156,14 @@ public class SqlConnPoolPeer
 
   private SqlConn open(SqlConnPool self)
   {
-    return SqlConnImpl.openDefault(self.uri, self.username, self.password);
+    SqlConn c = SqlConnImpl.openDefault(self.uri, self.username, self.password);
+    self.onOpen(c);
+    return c;
   }
 
   private void close(SqlConnPool self, Entry entry)
   {
+    self.onClose(entry.conn);
     entry.conn.close();
   }
 

--- a/src/sql/java/StatementPeer.java
+++ b/src/sql/java/StatementPeer.java
@@ -83,7 +83,7 @@ public class StatementPeer
   /**
    * Invoke the 'eachFunc' on every row in the result.
    */
-  void each(ResultSet rs, Func eachFunc)
+  Object each(ResultSet rs, Func eachFunc, boolean isWhile)
     throws SQLException
   {
     Cols cols = makeCols(rs);
@@ -95,8 +95,10 @@ public class StatementPeer
         row = makeRow(rs, cols, converters);
       else
         updateRow(rs, row, converters);
-      eachFunc.call(row);
+      Object r = eachFunc.call(row);
+      if (isWhile && (r != null)) return r;
     }
+    return null;
   }
 
   /**
@@ -183,6 +185,17 @@ public class StatementPeer
 
   public void queryEach(Statement self, Map params, Func eachFunc)
   {
+    doQueryEach(self, params, eachFunc, false);
+  }
+
+  public Object queryEachWhile(Statement self, Map params, Func eachFunc)
+  {
+    return doQueryEach(self, params, eachFunc, true);
+  }
+
+  private Object doQueryEach(
+      Statement self, Map params, Func eachFunc, boolean isWhile)
+  {
     try
     {
       ResultSet rs = null;
@@ -197,7 +210,7 @@ public class StatementPeer
         rs = stmt.executeQuery(self.sql);
       }
 
-      each(rs, eachFunc);
+      return each(rs, eachFunc, isWhile);
     }
     catch (SQLException ex)
     {

--- a/src/sql/pod.fandoc
+++ b/src/sql/pod.fandoc
@@ -36,16 +36,15 @@ To setup the fantest database and user account via the mysql command line:
   mysql -u root -p
   mysql> create user fantest identified by 'fantest';
   mysql> create database fantest;
-  mysql> grant all privileges on fantest.* to fantest identified by 'fantest';
+  mysql> grant all privileges on fantest.* to fantest;
 
 To use Postgres as the test database, modify "etc/sql/config.props" so that
-'test.uri' equals "jdbc:postgresql://localhost/postgres", and then setup the
+'test.uri' equals "jdbc:postgresql://localhost:5432/postgres", and then setup 
 the fantest database and user account via the Postgres command line:
   sudo -u postgres psql
   postgres=# create role fantest with password 'fantest';
   postgres=# alter role fantest with login;
   postgres=# create schema authorization fantest;
-  postgres=# set search_path to fantest;
 
 Connections [#connections]
 **************************

--- a/src/sql/pod.fandoc
+++ b/src/sql/pod.fandoc
@@ -38,6 +38,15 @@ To setup the fantest database and user account via the mysql command line:
   mysql> create database fantest;
   mysql> grant all privileges on fantest.* to fantest identified by 'fantest';
 
+To use Postgres as the test database, modify "etc/sql/config.props" so that
+'test.uri' equals "jdbc:postgresql://localhost/postgres", and then setup the
+the fantest database and user account via the Postgres command line:
+  sudo -u postgres psql
+  postgres=# create role fantest with password 'fantest';
+  postgres=# alter role fantest with login;
+  postgres=# create schema authorization fantest;
+  postgres=# set search_path to fantest;
+
 Connections [#connections]
 **************************
 Connections are managed by the `sql::SqlConn` class.  To open and close connections

--- a/src/sql/test/SqlServiceTest.fan
+++ b/src/sql/test/SqlServiceTest.fan
@@ -81,7 +81,7 @@ class SqlServiceTest : Test
 //////////////////////////////////////////////////////////////////////////
 
   **
-  ** Drop all tables in the database
+  ** Verify the metadata
   **
   Void verifyMeta()
   {
@@ -110,60 +110,45 @@ class SqlServiceTest : Test
   {
     verifyEq(db.meta.tableExists("foo_bar_should_not_exist"), false)
 
-    // TODO Currently, SqlMetaPeer.java fetches every single table from every
-    // schema.  In Postgres, this means it ends up fetching all the various
-    // system tables as well, which we then try to drop, which is bad.  We
-    // should probably fix SqlMeta so it can fetch tables for a specific
-    // schema.  In our test case here, that schema would be 'fantest'.
+    // TODO Currently, db.meta.tables fetches every single table from every
+    // schema.  In both Postgres and MySQL, this means it ends up fetching all
+    // the various system tables as well.  We should probably fix SqlMeta so it
+    // can fetch tables for a specific schema.  In our test case here, that
+    // schema would be 'fantest'.
     //
-    // For now, I've modified this test so that if we are running postgres, it
-    // just tries to drop the one table that actually gets created in the
-    // 'fantest' schema.
+    // In the original version of this test, it tried to drop every single one
+    // of these system tables, which fails spectacularly.  I'm not sure how
+    // this test ever worked before.
+    //
+    // I've modified this test so that it just tries to drop the one table that
+    // actually gets created in the 'fantest' schema, namely 'farmers'.
 
-    if (dbType == DbType.postgres)
-    {
-      Str[] tables := ["farmers"]
-      tables.each |Str tableName|
-      {
-        if (db.meta.tableExists(tableName))
-        {
-          try
-          {
-            db.sql("drop table $tableName").execute
-            tables.remove(tableName)
-          }
-          catch (Err e)
-          {
-            e.trace
-          }
-        }
-      }
-    }
-    else
-    {
-      Str[] tables := db.meta.tables.dup
-      while (tables.size != 0)
-      {
-        Int dropped := 0
-        tables.each |Str tableName|
-        {
-          verifyEq(db.meta.tableExists(tableName), true)
-          try
-          {
-            db.sql("drop table $tableName").execute
-            tables.remove(tableName)
-            dropped++
-          }
-          catch (Err e)
-          {
-            e.trace
-          }
-        }
+    if (db.meta.tableExists("farmers"))
+      db.sql("drop table farmers").execute
 
-        if (dropped == 0)
-          throw SqlErr("All tables could not be dropped.")
-      }
-    }
+    // OLD VERSION
+    //Str[] tables := db.meta.tables.dup
+    //while (tables.size != 0)
+    //{
+    //  Int dropped := 0
+    //  tables.each |Str tableName|
+    //  {
+    //    verifyEq(db.meta.tableExists(tableName), true)
+    //    try
+    //    {
+    //      db.sql("drop table $tableName").execute
+    //      tables.remove(tableName)
+    //      dropped++
+    //    }
+    //    catch (Err e)
+    //    {
+    //      e.trace
+    //    }
+    //  }
+    //
+    //  if (dropped == 0)
+    //    throw SqlErr("All tables could not be dropped.")
+    //}
   }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/sql/test/SqlServiceTest.fan
+++ b/src/sql/test/SqlServiceTest.fan
@@ -415,6 +415,16 @@ class SqlServiceTest : Test
       }
       i++
     }
+
+    // queryEachWhile
+    verifyEq(
+      db.sql("select * from farmers").queryEachWhile(null) |row->Obj?|
+        { return (row->age == 40) ? row->name : null },
+      "Donny")
+    verifyEq(
+      db.sql("select * from farmers").queryEachWhile(null) |row->Obj?|
+        { return (row->name == "Frodo") ? row->age : null },
+      null)
   }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR contains various improvements to the sql pod:

- Add `queryEachWhile()` to `Statement`
- Add `onOpen()` and `onClose()` to `SqlConnPool`
- Close all ResultSets properly
- Modify the test suite so that it works for both Postgres and MySQL
- Update the documentation