### PR TITLE
sql: fix so that writing a byte array only writes the bytes being used

### DIFF
--- a/src/sql/java/SqlUtil.java
+++ b/src/sql/java/SqlUtil.java
@@ -62,7 +62,7 @@ public class SqlUtil
     }
     else if (value instanceof MemBuf)
     {
-      jobj = ((MemBuf)value).buf;
+      jobj = ((MemBuf)value).bytes();
     }
     // Support for Postgres text[] <--> Fantom Str[]
     else if ((value instanceof List) && (((List) value).of().equals(Sys.StrType)))


### PR DESCRIPTION
This is a fix for a bug in the sql pod, so that we now only write out the bytes in a MemBuf that are actually being used, instead of writing out the entire capacity of the MemBuf.