### PR TITLE
util: fix JsonOutStream so characters below 0x20 are encoded properly.

### DIFF
--- a/src/util/fan/JsonOutStream.fan
+++ b/src/util/fan/JsonOutStream.fan
@@ -149,7 +149,11 @@ class JsonOutStream : OutStream
           case '\t': writeChar('\\').writeChar('t')
           case '\\': writeChar('\\').writeChar('\\')
           case '"':  writeChar('\\').writeChar('"')
-          default: writeChar(char)
+          default:
+            if (char < 0x20)
+              writeChar('\\').writeChar('u').print(char.toHex(4))
+            else
+              writeChar(char)
         }
       }
       else

--- a/src/util/test/JsonTest.fan
+++ b/src/util/test/JsonTest.fan
@@ -61,6 +61,24 @@ class JsonTest : Test
     verifyErr(ParseErr#) { JsonInStream("""{"x":4,""".in).readJson }
   }
 
+  Void testUnprintable()
+  {
+    verifyBasics(
+      "\"\\u0000\"",
+      Str.fromChars([0]))
+
+    verifyBasics(
+      "\"abc\\u0000\"",
+      Str.fromChars(['a', 'b', 'c', 0]))
+
+    chars := Int[,]
+    for (i := 0; i < 32; i++)
+      chars.add(i)
+    verifyBasics(
+      "\"\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\b\\t\\n\\u000b\\f\\r\\u000e\\u000f\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001a\\u001b\\u001c\\u001d\\u001e\\u001f\"",
+      Str.fromChars(chars))
+  }
+
   Void verifyBasics(Str s, Obj? expected)
   {
     // verify object stand alone


### PR DESCRIPTION
For JSON strings, the characters that are below `0x20`, but are not one of `\b`, `\f`, `\n`, `\r` or `\t`, are not being escaped into `\uXXXX` format by JsonOutStream.  For example, `0x00` is not being properly escaped into `\u0000`.  This PR fixes that bug.

JsonInStream's current behaviour is that it can properly decode escaped sequences like `\u0000`, but it _also_ will decode raw unescaped bytes like `0x00`.  I think this may not really allowed by the JSON spec, but this PR does not have a fix for that behaviour.

