### PR TITLE
sql: improve support for Postgres array fields

### DIFF
--- a/src/sql/java/SqlUtil.java
+++ b/src/sql/java/SqlUtil.java
@@ -70,19 +70,19 @@ public class SqlUtil
     {
       List list = (List) value;
 
-      // Str
+      // postgres text array
       if (list.of().equals(Sys.StrType))
       {
-        String[] arr = new String[(int)list.size()];
-        for (int i = 0; i < list.size(); i++)
+        String[] arr = new String[list.sz()];
+        for (int i = 0; i < list.sz(); i++)
           arr[i] = (String) list.get(i);
         jobj = arr;
       }
-      // Int
+      // postgres int/bigint array (works for both)
       else if (list.of().equals(Sys.IntType))
       {
-        Long[] arr = new Long[(int)list.size()];
-        for (int i = 0; i < list.size(); i++)
+        Long[] arr = new Long[list.sz()];
+        for (int i = 0; i < list.sz(); i++)
           arr[i] = (Long) list.get(i);
         jobj = arr;
       }
@@ -368,18 +368,24 @@ public class SqlUtil
     {
       Object arr = ((java.sql.Array) rs.getObject(col)).getArray();
 
+      // postgres text array
       if (arr instanceof String[])
       {
         return new List(Sys.StrType, (String[]) arr);
       }
+      // postgres int array
       else if (arr instanceof Integer[])
       {
-        Integer[] intArr = (Integer[]) arr;
-        Long[] lngArr = new Long[(int)intArr.length];
-        for (int i = 0; i < intArr.length; i++)
-          lngArr[i] = new Long(intArr[i]);
-        return new List(Sys.IntType, lngArr);
+        // We have to copy the Integer[] over to a Long[]
+        Integer[] src = (Integer[]) arr;
+        Long[] dst = new Long[src.length];
+
+        for (int i = 0; i < src.length; i++)
+          dst[i] = src[i].longValue();
+
+        return new List(Sys.IntType, dst);
       }
+      // postgres bigint array
       else if (arr instanceof Long[])
       {
         return new List(Sys.IntType, (Long[]) arr);

--- a/src/sql/java/SqlUtil.java
+++ b/src/sql/java/SqlUtil.java
@@ -65,14 +65,31 @@ public class SqlUtil
     {
       jobj = ((Buf)value).javaIn();
     }
-    // Support for Postgres text[] <--> Fantom Str[]
-    else if ((value instanceof List) && (((List) value).of().equals(Sys.StrType)))
+    // Support for converting Fantom Lists to Postgres arrays.
+    else if (value instanceof List)
     {
       List list = (List) value;
-      String[] arr = new String[(int)list.size()];
-      for (int i = 0; i < list.size(); i++)
-        arr[i] = list.get(i).toString();
-      jobj = arr;
+
+      // Str
+      if (list.of().equals(Sys.StrType))
+      {
+        String[] arr = new String[(int)list.size()];
+        for (int i = 0; i < list.size(); i++)
+          arr[i] = (String) list.get(i);
+        jobj = arr;
+      }
+      // Int
+      else if (list.of().equals(Sys.IntType))
+      {
+        Long[] arr = new Long[(int)list.size()];
+        for (int i = 0; i < list.size(); i++)
+          arr[i] = (Long) list.get(i);
+        jobj = arr;
+      }
+      else
+      {
+        throw SqlErr.make("Cannot create array from " + list.of());
+      }
     }
 
     return jobj;
@@ -343,16 +360,34 @@ public class SqlUtil
     }
   }
 
-  // Support for Postgres text[] <--> Fantom Str[]
+  // Support for converting Postgres arrays to Fantom Lists.
   public static class ToFanList extends SqlToFan
   {
     public Object toObj(ResultSet rs, int col)
       throws SQLException
     {
-      String[] arr = (String[])
-        ((java.sql.Array) rs.getObject(col)).getArray();
+      Object arr = ((java.sql.Array) rs.getObject(col)).getArray();
 
-      return new List(Sys.StrType, arr);
+      if (arr instanceof String[])
+      {
+        return new List(Sys.StrType, (String[]) arr);
+      }
+      else if (arr instanceof Integer[])
+      {
+        Integer[] intArr = (Integer[]) arr;
+        Long[] lngArr = new Long[(int)intArr.length];
+        for (int i = 0; i < intArr.length; i++)
+          lngArr[i] = new Long(intArr[i]);
+        return new List(Sys.IntType, lngArr);
+      }
+      else if (arr instanceof Long[])
+      {
+        return new List(Sys.IntType, (Long[]) arr);
+      }
+      else
+      {
+        throw SqlErr.make("Cannot create array from " + arr.getClass());
+      }
     }
   }
 


### PR DESCRIPTION
Add read/write support for Postgres's 4-byte `int[]` array field, and 8-byte `bigint[]` array field.
