### PR TITLE
sql:  Add support for more postgres array types

### DIFF
--- a/src/sql/java/SqlUtil.java
+++ b/src/sql/java/SqlUtil.java
@@ -86,6 +86,25 @@ public class SqlUtil
           arr[i] = (Long) list.get(i);
         jobj = arr;
       }
+      // postgres real/double precision array (works for both)
+      else if (list.of().equals(Sys.FloatType))
+      {
+        Double[] arr = new Double[list.sz()];
+        for (int i = 0; i < list.sz(); i++)
+          arr[i] = (Double) list.get(i);
+        jobj = arr;
+      }
+      // postgres timestamptz
+      else if (list.of().equals(Sys.DateTimeType))
+      {
+        Timestamp[] arr = new Timestamp[list.sz()];
+        for (int i = 0; i < list.sz(); i++)
+        {
+          DateTime dt = (DateTime) list.get(i);
+          arr[i] = new Timestamp(dt.toJava());
+        }
+        jobj = arr;
+      }
       else
       {
         throw SqlErr.make("Cannot create array from " + list.of());
@@ -389,6 +408,35 @@ public class SqlUtil
       else if (arr instanceof Long[])
       {
         return new List(Sys.IntType, (Long[]) arr);
+      }
+      // postgres real array
+      else if (arr instanceof Float[])
+      {
+        // We have to copy the Float[] over to a Double[]
+        Float[] src = (Float[]) arr;
+        Double[] dst = new Double[src.length];
+
+        for (int i = 0; i < src.length; i++)
+          dst[i] = src[i].doubleValue();
+
+        return new List(Sys.FloatType, dst);
+      }
+      // postgres double precision array
+      else if (arr instanceof Double[])
+      {
+        return new List(Sys.FloatType, (Double[]) arr);
+      }
+      // postgres timestamptz array
+      else if (arr instanceof Timestamp[])
+      {
+        // We have to copy the Timestamp[] over to a DateTime[]
+        Timestamp[] src = (Timestamp[]) arr;
+        DateTime[] dst = new DateTime[src.length];
+
+        for (int i = 0; i < src.length; i++)
+          dst[i] = DateTime.fromJava(src[i].getTime());
+
+        return new List(Sys.DateTimeType, dst);
       }
       else
       {

--- a/src/sql/java/SqlUtil.java
+++ b/src/sql/java/SqlUtil.java
@@ -86,6 +86,14 @@ public class SqlUtil
           arr[i] = (Long) list.get(i);
         jobj = arr;
       }
+      // postgres boolean array
+      else if (list.of().equals(Sys.BoolType))
+      {
+        Boolean[] arr = new Boolean[list.sz()];
+        for (int i = 0; i < list.sz(); i++)
+          arr[i] = (Boolean) list.get(i);
+        jobj = arr;
+      }
       // postgres real/double precision array (works for both)
       else if (list.of().equals(Sys.FloatType))
       {
@@ -408,6 +416,11 @@ public class SqlUtil
       else if (arr instanceof Long[])
       {
         return new List(Sys.IntType, (Long[]) arr);
+      }
+      // postgres boolean array
+      else if (arr instanceof Boolean[])
+      {
+        return new List(Sys.BoolType, (Boolean[]) arr);
       }
       // postgres real array
       else if (arr instanceof Float[])

--- a/src/sql/test/SqlTest.fan
+++ b/src/sql/test/SqlTest.fan
@@ -691,6 +691,7 @@ class SqlTest : Test
          texts   text[],
          ints    int[],
          longs   bigint[],
+         bools   boolean[],
          floats  real[],
          doubles double precision[],
          times   timestamptz[])"
@@ -700,13 +701,14 @@ class SqlTest : Test
     now := DateTime.now
 
     insert := db.sql(
-      "insert into list (texts, ints, longs, floats, doubles, times)
-       values (@texts, @ints, @longs, @floats, @doubles, @times)").prepare
+      "insert into list (texts, ints, longs, bools, floats, doubles, times)
+       values (@texts, @ints, @longs, @bools, @floats, @doubles, @times)").prepare
 
     insert.execute([
       "texts":   Str["a", "b", "c"],
       "ints":    Int[1, 2, 3],
       "longs":   Int[base+1, base+2, base+3],
+      "bools":   Bool[true, false],
       "floats":  Float[1.0f, 2.0f, 3.0f],
       "doubles": Float[4.0f, 5.0f, 6.0f],
       "times":   DateTime[now.plus(1hr), now.plus(2hr), now.plus(3hr)],
@@ -718,6 +720,7 @@ class SqlTest : Test
     verifyEq(rows[0]->texts,   Str["a", "b", "c"])
     verifyEq(rows[0]->ints,    Int[1, 2, 3])
     verifyEq(rows[0]->longs,   Int[base+1, base+2, base+3])
+    verifyEq(rows[0]->bools,   Bool[true, false])
     verifyEq(rows[0]->floats,  Float[1.0f, 2.0f, 3.0f])
     verifyEq(rows[0]->doubles, Float[4.0f, 5.0f, 6.0f])
     verifyEq(rows[0]->times,   DateTime[now.plus(1hr), now.plus(2hr), now.plus(3hr)])

--- a/src/sql/test/SqlTest.fan
+++ b/src/sql/test/SqlTest.fan
@@ -682,36 +682,45 @@ class SqlTest : Test
   Void postgresList()
   {
     if (dbType != DbType.postgres) return
-    echo("postgresList")
 
     if (db.meta.tableExists("list"))
       db.sql("drop table list").execute
 
     db.sql(
       "create table list (
-         text_arr text[],
-         int_arr  int[],
-         long_arr bigint[])"
+         texts   text[],
+         ints    int[],
+         longs   bigint[],
+         floats  real[],
+         doubles double precision[],
+         times   timestamptz[])"
        ).execute
 
     base := 3000000000 // Larger than Integer.MAX_VALUE
+    now := DateTime.now
 
     insert := db.sql(
-      "insert into list (text_arr, int_arr, long_arr)
-       values (@textArr, @intArr, @longArr)").prepare
+      "insert into list (texts, ints, longs, floats, doubles, times)
+       values (@texts, @ints, @longs, @floats, @doubles, @times)").prepare
 
     insert.execute([
-      "textArr": Str["a", "b", "c"],
-      "intArr":  Int[1, 2, 3],
-      "longArr": Int[base+1, base+2, base+3],
+      "texts":   Str["a", "b", "c"],
+      "ints":    Int[1, 2, 3],
+      "longs":   Int[base+1, base+2, base+3],
+      "floats":  Float[1.0f, 2.0f, 3.0f],
+      "doubles": Float[4.0f, 5.0f, 6.0f],
+      "times":   DateTime[now.plus(1hr), now.plus(2hr), now.plus(3hr)],
     ])
 
     select := db.sql("select * from list").prepare
     rows := select.query()
     verifyEq(rows.size, 1)
-    verifyEq(rows[0]->text_arr, Str["a", "b", "c"])
-    verifyEq(rows[0]->int_arr,  Int[1, 2, 3])
-    verifyEq(rows[0]->long_arr, Int[base+1, base+2, base+3])
+    verifyEq(rows[0]->texts,   Str["a", "b", "c"])
+    verifyEq(rows[0]->ints,    Int[1, 2, 3])
+    verifyEq(rows[0]->longs,   Int[base+1, base+2, base+3])
+    verifyEq(rows[0]->floats,  Float[1.0f, 2.0f, 3.0f])
+    verifyEq(rows[0]->doubles, Float[4.0f, 5.0f, 6.0f])
+    verifyEq(rows[0]->times,   DateTime[now.plus(1hr), now.plus(2hr), now.plus(3hr)])
   }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add support for more postgres array types:  `bool[]`, `real[]`, `double precision[]`, and `timestamptz[]`.