### PR TITLE
Fix iterator skipping first element & returning NoSuchElementException early

### DIFF
--- a/src/sys/java/fan/sys/List.java
+++ b/src/sys/java/fan/sys/List.java
@@ -1653,10 +1653,8 @@ public final class List<V>
 
     public Object next()
     {
-      int i = cursor + 1;
-      if (i >= size) throw new NoSuchElementException();
-      cursor = i;
-      return (V) values[cursor];
+      if (cursor >= size) throw new NoSuchElementException();
+      return (V) values[cursor++];
     }
 
     public int nextIndex()


### PR DESCRIPTION
ListItr was incorrectly incrementing the iterator before retrieving the value when the rest of the methods expect that cursor always points to the next index (see nextIndex method).

 On top of that next() was also throwing NoSuchElementException when hasNext was still true due to the same issue.
 
 With this fix you can now use foreach loop in Java without hitting a NoSuchElementException