### PR TITLE
Various bug fixes and improvements in sql::SqlConnPool

### DIFF
--- a/src/sql/fan/SqlConn.fan
+++ b/src/sql/fan/SqlConn.fan
@@ -44,6 +44,12 @@ mixin SqlConn
   **
   abstract Bool isClosed()
 
+  **
+  ** Return if this connection is still alive and usable.  For JDBC
+  ** connections this pings the database using 'java.sql.Connection.isValid'.
+  **
+  @NoDoc virtual Bool isValid() { true }
+
 //////////////////////////////////////////////////////////////////////////
 // Data
 //////////////////////////////////////////////////////////////////////////

--- a/src/sql/fan/SqlConnImpl.fan
+++ b/src/sql/fan/SqlConnImpl.fan
@@ -45,6 +45,11 @@ class SqlConnImpl : SqlConn
   **
   override native Bool isClosed()
 
+  **
+  ** Ping that the connection is still alive using JDBC Connection.isValid.
+  **
+  @NoDoc override native Bool isValid()
+
 //////////////////////////////////////////////////////////////////////////
 // Data
 //////////////////////////////////////////////////////////////////////////
@@ -94,12 +99,22 @@ internal class TestSqlConn: SqlConn
   const Int id
   override Bool close() { closed = true}
   override Bool isClosed() { return closed }
+  override Bool isValid() { valid }
   override SqlMeta meta() { throw Err() }
   override Statement sql(Str sql) { throw Err() }
   override Bool autoCommit
-  override Void commit() {}
-  override Void rollback() {}
+  {
+    set { ops.add("autoCommit($it)"); &autoCommit = it }
+  }
+  override Void commit() { commits++; ops.add("commit") }
+  override Void rollback() { rollbacks++; ops.add("rollback") }
   override Str toStr() { "TestSqlConn-$id" }
   private Bool closed
+
+  // test hooks to simulate failures and record pool behavior
+  Bool valid := true
+  Int commits
+  Int rollbacks
+  Str[] ops := [,]
 }
 

--- a/src/sql/fan/SqlConnPool.fan
+++ b/src/sql/fan/SqlConnPool.fan
@@ -48,6 +48,11 @@ const class SqlConnPool
   ** until released back to the pool.
   const Duration maxLifetime := 30min
 
+  ** Time a connection may be held by an execute callback before
+  ** checkLinger logs a warning that it may be stuck or leaked.
+  ** The warning is logged once per checkout.
+  const Duration leakWarn := 2min
+
   ** onOpen is invoked just after a connection is opened by the pool.
   protected virtual Void onOpen(SqlConn c) {}
 
@@ -76,7 +81,8 @@ const class SqlConnPool
   native Void execute(|SqlConn| f)
 
   ** Close idle connections that have lingered past the linger timeout
-  ** or lived past the maxLifetime.
+  ** or lived past the maxLifetime.  Also log a warning for connections
+  ** held in-use longer than leakWarn.
   native Void checkLinger()
 
   ** Return if [close] has been called.

--- a/src/sql/fan/SqlConnPool.fan
+++ b/src/sql/fan/SqlConnPool.fan
@@ -31,6 +31,12 @@ const class SqlConnPool
   ** Max time to block waiting for a connection before raising TimeoutErr
   const Duration timeout := 30sec
 
+  ** Max time to wait when opening a new connection to the database
+  ** before failing.  If null then the JDBC driver default is used.
+  ** Note this is implemented via the global DriverManager.setLoginTimeout
+  ** which applies JVM wide to all JDBC connections.
+  const Duration? connectTimeout := null
+
   ** Time to linger an idle connection before closing it.  An external
   ** actor must call checkLinger periodically to close idle connetions.
   const Duration linger := 5min

--- a/src/sql/fan/SqlConnPool.fan
+++ b/src/sql/fan/SqlConnPool.fan
@@ -35,6 +35,13 @@ const class SqlConnPool
   ** actor must call checkLinger periodically to close idle connetions.
   const Duration linger := 5min
 
+  ** Max lifetime of a connection before it is retired, regardless of
+  ** how recently it was used.  This protects against database and
+  ** network infrastructure that kills long lived connections.  It is
+  ** enforced by checkLinger; connections in use are never retired
+  ** until released back to the pool.
+  const Duration maxLifetime := 30min
+
   ** onOpen is invoked just after a connection is opened by the pool.
   protected virtual Void onOpen(SqlConn c) {}
 
@@ -62,7 +69,8 @@ const class SqlConnPool
   ** Do not close the connection inside the callback.
   native Void execute(|SqlConn| f)
 
-  ** Close idle connections that have lingered past the linger timeout.
+  ** Close idle connections that have lingered past the linger timeout
+  ** or lived past the maxLifetime.
   native Void checkLinger()
 
   ** Return if [close] has been called.

--- a/src/sql/java/SqlConnImplPeer.java
+++ b/src/sql/java/SqlConnImplPeer.java
@@ -79,6 +79,21 @@ public class SqlConnImplPeer
     }
   }
 
+  public boolean isValid(SqlConnImpl self)
+  {
+    try
+    {
+      return jconn.isValid(isValidTimeout);
+    }
+    catch (Throwable e)
+    {
+      return false;
+    }
+  }
+
+  // seconds passed to java.sql.Connection.isValid
+  static final int isValidTimeout = 3;
+
   public boolean close(SqlConnImpl self)
   {
     try

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -85,7 +85,28 @@ public class SqlConnPoolPeer
     this.entries = keep;
   }
 
-  private synchronized Entry allocate(SqlConnPool self)
+  private Entry allocate(SqlConnPool self)
+    throws InterruptedException
+  {
+    long deadline = System.nanoTime()/1000000L + self.timeout.millis();
+    while (true)
+    {
+      Entry entry = allocateEntry(self, deadline);
+
+      // skip validation if entry was used recently, which
+      // includes connections just opened by doAllocate
+      long idle = Duration.nowTicks() - entry.lastUse;
+      if (idle < validateThreshold) return entry;
+
+      // ping connection to verify it is still alive; if not then
+      // close it, discard it from the pool, and allocate again
+      if (validate(entry)) return entry;
+      self.log.warn("SqlConnPool evicting broken connection: " + entry.conn);
+      evict(self, entry);
+    }
+  }
+
+  private synchronized Entry allocateEntry(SqlConnPool self, long deadline)
     throws InterruptedException
   {
     // try top find an available entry
@@ -93,8 +114,6 @@ public class SqlConnPoolPeer
     if (entry != null) return entry;
 
     // block until one frees up
-    long msTimeout = self.timeout.millis();
-    long deadline = System.nanoTime()/1000000L + msTimeout;
     while (true)
     {
       // check if we have waited past our deadline
@@ -111,6 +130,28 @@ public class SqlConnPoolPeer
 
     // raise timeout error
     throw TimeoutErr.make("SqlConn cannot be acquired (" + self.timeout + ")");
+  }
+
+  private boolean validate(Entry entry)
+  {
+    // pool only creates SqlConnImpl; treat anything else as valid
+    if (!(entry.conn instanceof SqlConnImpl)) return true;
+    try
+    {
+      return ((SqlConnImpl)entry.conn).peer.jconn.isValid(validateTimeout);
+    }
+    catch (Throwable e)
+    {
+      return false;
+    }
+  }
+
+  private void evict(SqlConnPool self, Entry entry)
+  {
+    // remove from pool under lock, but close outside the
+    // lock since closing may block on network I/O
+    synchronized (this) { entries.remove(entry); notifyAll(); }
+    close(self, entry);
   }
 
   private Entry doAllocate(SqlConnPool self)
@@ -217,6 +258,13 @@ public class SqlConnPoolPeer
 //////////////////////////////////////////////////////////////////////////
 // Fields
 //////////////////////////////////////////////////////////////////////////
+
+  // only validate a connection on borrow if it has been idle
+  // longer than this threshold (in Duration ticks)
+  private static final long validateThreshold = 500L * 1000000L;  // 500ms
+
+  // seconds passed to java.sql.Connection.isValid on borrow
+  private static final int validateTimeout = 3;
 
   private ArrayList<Entry> entries = new ArrayList<>();
   private boolean closed;

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -173,11 +173,9 @@ public class SqlConnPoolPeer
 
   private boolean validate(Entry entry)
   {
-    // pool only creates SqlConnImpl; treat anything else as valid
-    if (!(entry.conn instanceof SqlConnImpl)) return true;
     try
     {
-      return ((SqlConnImpl)entry.conn).peer.jconn.isValid(validateTimeout);
+      return entry.conn.isValid();
     }
     catch (Throwable e)
     {
@@ -334,9 +332,6 @@ public class SqlConnPoolPeer
   // only validate a connection on borrow if it has been idle
   // longer than this threshold (in Duration ticks)
   private static final long validateThreshold = 500L * 1000000L;  // 500ms
-
-  // seconds passed to java.sql.Connection.isValid on borrow
-  private static final int validateTimeout = 3;
 
   private ArrayList<Entry> entries = new ArrayList<>();
   private boolean closed;

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -84,6 +84,19 @@ public class SqlConnPoolPeer
       long linger = self.linger.ticks();
       long maxLifetime = self.maxLifetime.ticks();
 
+      // warn once per checkout for connections held in-use
+      // suspiciously long; likely a stuck query or hung callback
+      long leakWarn = self.leakWarn.ticks();
+      for (int i=0; i<entries.size(); ++i)
+      {
+        Entry entry = entries.get(i);
+        if (entry.inUse && !entry.leakWarned && (now - entry.useStart) > leakWarn)
+        {
+          entry.leakWarned = true;
+          self.log.warn("SqlConnPool connection held in-use longer than " + self.leakWarn + ": " + entry.conn);
+        }
+      }
+
       // check common case efficiently just to see if we have any to close
       boolean anyToClose = false;
       for (int i=0; i<entries.size(); ++i)
@@ -195,6 +208,7 @@ public class SqlConnPoolPeer
     if (entry != null)
     {
       entry.inUse = true;
+      entry.useStart = Duration.nowTicks();
       return entry;
     }
 
@@ -203,6 +217,7 @@ public class SqlConnPoolPeer
     {
       entry = new Entry(open(self));
       entry.inUse = true;
+      entry.useStart = entry.created;
       entries.add(entry);
       return entry;
     }
@@ -236,6 +251,7 @@ public class SqlConnPoolPeer
     synchronized (this)
     {
       entry.inUse = false;
+      entry.leakWarned = false;
       entry.lastUse = Duration.nowTicks();
       notifyAll();
     }
@@ -301,6 +317,8 @@ public class SqlConnPoolPeer
     final long created;   // Duration.ticks when connection was opened
     boolean inUse;        // is this entry currently being used
     long lastUse;         // Duration.ticks of last execute
+    long useStart;        // Duration.ticks when current use began
+    boolean leakWarned;   // have we warned about current use being stuck
 
     public String toString()
     {

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -55,39 +55,57 @@ public class SqlConnPoolPeer
     return closed;
   }
 
-  public synchronized void close(SqlConnPool self)
+  public void close(SqlConnPool self)
   {
-    if (closed) return;
-    closed = true;
-    for (int i=0; i<entries.size(); ++i)
-      close(self, entries.get(i));
-    entries.clear();
+    // remove all entries under the lock, then close them outside
+    // the lock since closing may block on network I/O; wake any
+    // blocked allocators so they fail fast instead of timing out
+    ArrayList<Entry> toClose;
+    synchronized (this)
+    {
+      if (closed) return;
+      closed = true;
+      toClose = entries;
+      entries = new ArrayList<>();
+      notifyAll();
+    }
+    for (int i=0; i<toClose.size(); ++i)
+      close(self, toClose.get(i));
   }
 
-  public synchronized void checkLinger(SqlConnPool self)
+  public void checkLinger(SqlConnPool self)
   {
-    long now = Duration.nowTicks();
-    long linger = self.linger.ticks();
-    long maxLifetime = self.maxLifetime.ticks();
-
-    // check common case efficiently just to see if we have any to close
-    boolean anyToClose = false;
-    for (int i=0; i<entries.size(); ++i)
+    // remove expired entries under the lock, then close them
+    // outside the lock since closing may block on network I/O
+    ArrayList<Entry> expired;
+    synchronized (this)
     {
-      Entry entry = entries.get(i);
-      if (isExpired(entry, now, linger, maxLifetime)) { anyToClose = true; break; }
-    }
-    if (!anyToClose) return;
+      long now = Duration.nowTicks();
+      long linger = self.linger.ticks();
+      long maxLifetime = self.maxLifetime.ticks();
 
-    // close expired entries and build new list of entries to keep
-    ArrayList<Entry> keep = new ArrayList<>(entries.size());
-    for (int i=0; i<entries.size(); ++i)
-    {
-      Entry entry = entries.get(i);
-      if (isExpired(entry, now, linger, maxLifetime)) close(self, entry);
-      else keep.add(entry);
+      // check common case efficiently just to see if we have any to close
+      boolean anyToClose = false;
+      for (int i=0; i<entries.size(); ++i)
+      {
+        Entry entry = entries.get(i);
+        if (isExpired(entry, now, linger, maxLifetime)) { anyToClose = true; break; }
+      }
+      if (!anyToClose) return;
+
+      // build new lists of entries to close and keep
+      ArrayList<Entry> keep = new ArrayList<>(entries.size());
+      expired = new ArrayList<>();
+      for (int i=0; i<entries.size(); ++i)
+      {
+        Entry entry = entries.get(i);
+        if (isExpired(entry, now, linger, maxLifetime)) expired.add(entry);
+        else keep.add(entry);
+      }
+      this.entries = keep;
     }
-    this.entries = keep;
+    for (int i=0; i<expired.size(); ++i)
+      close(self, expired.get(i));
   }
 
   private static boolean isExpired(Entry entry, long now, long linger, long maxLifetime)
@@ -121,27 +139,23 @@ public class SqlConnPoolPeer
   private synchronized Entry allocateEntry(SqlConnPool self, long deadline)
     throws InterruptedException
   {
-    // try top find an available entry
-    Entry entry = doAllocate(self);
-    if (entry != null) return entry;
-
-    // block until one frees up
     while (true)
     {
+      // check that we aren't closed
+      if (closed) throw Err.make("SqlConnPool is closed");
+
+      // try to find an available entry or open a new one
+      Entry entry = doAllocate(self);
+      if (entry != null) return entry;
+
       // check if we have waited past our deadline
       long toSleep = deadline - System.nanoTime()/1000000L;
-      if (toSleep <= 0) break;
+      if (toSleep <= 0)
+        throw TimeoutErr.make("SqlConn cannot be acquired (" + self.timeout + ")");
 
       // sleep until we get a notify
       wait(toSleep);
-
-      // try again
-      entry = doAllocate(self);
-      if (entry != null) return entry;
     }
-
-    // raise timeout error
-    throw TimeoutErr.make("SqlConn cannot be acquired (" + self.timeout + ")");
   }
 
   private boolean validate(Entry entry)
@@ -168,9 +182,6 @@ public class SqlConnPoolPeer
 
   private Entry doAllocate(SqlConnPool self)
   {
-    // check that we aren't closed
-    if (closed) throw Err.make("SqlConnPool is closed");
-
     // find most recently used entry that is not currently in use
     Entry entry = null;
     for (int i=0; i<entries.size(); ++i)
@@ -232,6 +243,11 @@ public class SqlConnPoolPeer
 
   private SqlConn open(SqlConnPool self)
   {
+    // bound how long a connect may block; note this is a JVM
+    // wide setting on DriverManager (see SqlConnPool fandoc)
+    if (self.connectTimeout != null)
+      DriverManager.setLoginTimeout((int)self.connectTimeout.toSec());
+
     SqlConn c = SqlConnImpl.openDefault(self.uri, self.username, self.password);
 
     // set auto-commit based on connection pool property

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -31,17 +31,23 @@ public class SqlConnPoolPeer
     throws Throwable
   {
     Entry entry = allocate(self);
-    Throwable err = null;
     try
     {
       f.call(entry.conn);
     }
     catch (Throwable e)
     {
-      err = e;
+      // if the error left the connection broken then evict it
+      // from the pool instead of releasing it back for reuse
+      if (validate(entry)) release(self, entry);
+      else
+      {
+        self.log.warn("SqlConnPool evicting broken connection: " + entry.conn);
+        evict(self, entry);
+      }
+      throw e;
     }
     release(self, entry);
-    if (err != null) throw err;
   }
 
   public boolean isClosed(SqlConnPool self)

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -182,7 +182,7 @@ public class SqlConnPoolPeer
     s.append("SqlConnPool\n");
     s.append("  uri:      ").append(self.uri).append("\n");
     s.append("  maxConns: ").append(self.maxConns).append("\n");
-    s.append("  linger:   ").append(self.maxConns).append("\n");
+    s.append("  linger:   ").append(self.linger).append("\n");
     s.append("  idle:     ").append(idle).append("\n");
     s.append("  inUse:    ").append(inUse).append("\n");
     s.append("  entries:  ").append(entries.size()).append("\n");

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -68,7 +68,7 @@ public class SqlConnPoolPeer
     for (int i=0; i<entries.size(); ++i)
     {
       Entry entry = entries.get(i);
-      boolean expired = (now - entry.lastUse) > linger;
+      boolean expired = !entry.inUse && (now - entry.lastUse) > linger;
       if (expired) { anyToClose = true; break; }
     }
     if (!anyToClose) return;
@@ -78,7 +78,7 @@ public class SqlConnPoolPeer
     for (int i=0; i<entries.size(); ++i)
     {
       Entry entry = entries.get(i);
-      boolean expired = (now - entry.lastUse) > linger;
+      boolean expired = !entry.inUse && (now - entry.lastUse) > linger;
       if (expired) close(self, entry);
       else keep.add(entry);
     }

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -68,14 +68,14 @@ public class SqlConnPoolPeer
   {
     long now = Duration.nowTicks();
     long linger = self.linger.ticks();
+    long maxLifetime = self.maxLifetime.ticks();
 
     // check common case efficiently just to see if we have any to close
     boolean anyToClose = false;
     for (int i=0; i<entries.size(); ++i)
     {
       Entry entry = entries.get(i);
-      boolean expired = !entry.inUse && (now - entry.lastUse) > linger;
-      if (expired) { anyToClose = true; break; }
+      if (isExpired(entry, now, linger, maxLifetime)) { anyToClose = true; break; }
     }
     if (!anyToClose) return;
 
@@ -84,11 +84,17 @@ public class SqlConnPoolPeer
     for (int i=0; i<entries.size(); ++i)
     {
       Entry entry = entries.get(i);
-      boolean expired = !entry.inUse && (now - entry.lastUse) > linger;
-      if (expired) close(self, entry);
+      if (isExpired(entry, now, linger, maxLifetime)) close(self, entry);
       else keep.add(entry);
     }
     this.entries = keep;
+  }
+
+  private static boolean isExpired(Entry entry, long now, long linger, long maxLifetime)
+  {
+    if (entry.inUse) return false;
+    return (now - entry.lastUse) > linger ||
+           (now - entry.created) > maxLifetime;
   }
 
   private Entry allocate(SqlConnPool self)
@@ -253,6 +259,7 @@ public class SqlConnPoolPeer
     s.append("  uri:      ").append(self.uri).append("\n");
     s.append("  maxConns: ").append(self.maxConns).append("\n");
     s.append("  linger:   ").append(self.linger).append("\n");
+    s.append("  maxLifetime: ").append(self.maxLifetime).append("\n");
     s.append("  idle:     ").append(idle).append("\n");
     s.append("  inUse:    ").append(inUse).append("\n");
     s.append("  entries:  ").append(entries.size()).append("\n");
@@ -270,10 +277,12 @@ public class SqlConnPoolPeer
     Entry(SqlConn conn)
     {
       this.conn    = conn;
-      this.lastUse = Duration.nowTicks();
+      this.created = Duration.nowTicks();
+      this.lastUse = this.created;
     }
 
     final SqlConn conn;   // open connection
+    final long created;   // Duration.ticks when connection was opened
     boolean inUse;        // is this entry currently being used
     long lastUse;         // Duration.ticks of last execute
 

--- a/src/sql/java/SqlConnPoolPeer.java
+++ b/src/sql/java/SqlConnPoolPeer.java
@@ -194,11 +194,34 @@ public class SqlConnPoolPeer
     return null;
   }
 
-  private synchronized void release(SqlConnPool self, Entry entry)
+  private void release(SqlConnPool self, Entry entry)
   {
-    entry.inUse = false;
-    entry.lastUse = Duration.nowTicks();
-    notifyAll();
+    // reset the connection so the next borrower gets a clean
+    // slate; if the reset fails then evict the connection
+    try
+    {
+      // roll back any uncommitted work first; must happen before
+      // restoring auto-commit since setAutoCommit(true) on a
+      // dangling transaction would commit it
+      if (!entry.conn.autoCommit()) entry.conn.rollback();
+
+      // restore pool's auto-commit mode in case callback changed it
+      boolean poolMode = self.autoCommit();
+      if (entry.conn.autoCommit() != poolMode) entry.conn.autoCommit(poolMode);
+    }
+    catch (Throwable e)
+    {
+      self.log.warn("SqlConnPool evicting broken connection: " + entry.conn);
+      evict(self, entry);
+      return;
+    }
+
+    synchronized (this)
+    {
+      entry.inUse = false;
+      entry.lastUse = Duration.nowTicks();
+      notifyAll();
+    }
   }
 
   private SqlConn open(SqlConnPool self)

--- a/src/sql/test/SqlConnPoolTest.fan
+++ b/src/sql/test/SqlConnPoolTest.fan
@@ -15,6 +15,10 @@ class SqlConnPoolTest : Test
 {
   Void test()
   {
+    // this test verifies connection ids by name, so reset the id
+    // counter in case other test methods already created connections
+    TestSqlConn.idCounter.val = 0
+
     cp := SqlConnPool
     {
       it.uri      = "test"
@@ -116,6 +120,189 @@ class SqlConnPoolTest : Test
     verifyPool(cp, actors, 0, 0, [null, null, null, null])
   }
 
+  Void testValidateOnBorrow()
+  {
+    cp := SqlConnPool { it.uri = "test" }
+    TestSqlConn? c1 := null
+    cp.execute |c| { c1 = c }
+
+    // recently used connections are reused without validation
+    c1.valid = false
+    TestSqlConn? c2 := null
+    cp.execute |c| { c2 = c }
+    verifySame(c1, c2)
+
+    // once idle past the validation threshold, the broken
+    // connection is evicted and replaced with a fresh one
+    Actor.sleep(600ms)
+    TestSqlConn? c3 := null
+    cp.execute |c| { c3 = c }
+    verifyNotSame(c1, c3)
+    verifyEq(c1.isClosed, true)
+    verifyEq(debugInt(cp.debug, "entries"), 1)
+    cp.close
+  }
+
+  Void testEvictOnError()
+  {
+    cp := SqlConnPool { it.uri = "test" }
+    TestSqlConn? c1 := null
+    cp.execute |c| { c1 = c }
+
+    // callback error with healthy connection: released for reuse
+    verifyErr(IOErr#) { cp.execute |c| { throw IOErr("boom") } }
+    verifyEq(c1.isClosed, false)
+    TestSqlConn? c2 := null
+    cp.execute |c| { c2 = c }
+    verifySame(c1, c2)
+
+    // callback error with broken connection: evicted
+    verifyErr(IOErr#) { cp.execute |c| { ((TestSqlConn)c).valid = false; throw IOErr("boom") } }
+    verifyEq(c1.isClosed, true)
+    verifyEq(debugInt(cp.debug, "entries"), 0)
+    TestSqlConn? c3 := null
+    cp.execute |c| { c3 = c }
+    verifyNotSame(c1, c3)
+    cp.close
+  }
+
+  Void testRollbackOnRelease()
+  {
+    // pool defaults to autoCommit false: every release rolls back
+    cp := SqlConnPool { it.uri = "test" }
+    verifyEq(cp.autoCommit, false)
+    TestSqlConn? c1 := null
+    cp.execute |c| { c1 = c }
+    verifyEq(c1.rollbacks, 1)
+    verifyEq(c1.autoCommit, false)
+    cp.execute |c| {}
+    verifyEq(c1.rollbacks, 2)
+    cp.close
+
+    // auto-commit pool: no rollback on release
+    cp2 := SqlConnPool { it.uri = "test"; it.autoCommit = true }
+    TestSqlConn? c2 := null
+    cp2.execute |c| { c2 = c }
+    verifyEq(c2.rollbacks, 0)
+    verifyEq(c2.autoCommit, true)
+
+    // callback flips into transaction mode and leaves dangling
+    // work: release must rollback before restoring auto-commit,
+    // since setAutoCommit(true) would commit the dangling txn
+    c2.ops.clear
+    cp2.execute |c| { c.autoCommit = false }
+    verifyEq(c2.ops, ["autoCommit(false)", "rollback", "autoCommit(true)"])
+    cp2.close
+  }
+
+  Void testMaxLifetime()
+  {
+    cp := SqlConnPool { it.uri = "test"; it.linger = 1min; it.maxLifetime = 100ms }
+    TestSqlConn? c1 := null
+    cp.execute |c| { c1 = c }
+
+    // keep connection busy so linger never applies
+    5.times { Actor.sleep(30ms); cp.execute |c| { verifySame(c, c1) } }
+
+    // retired by age even though never idle
+    cp.checkLinger
+    verifyEq(c1.isClosed, true)
+    verifyEq(debugInt(cp.debug, "entries"), 0)
+    cp.close
+  }
+
+  Void testInUseNotReaped()
+  {
+    cp := SqlConnPool { it.uri = "test"; it.linger = 50ms; it.maxLifetime = 50ms }
+    ap := ActorPool()
+    a := SqlConnPoolTestActor(ap, cp, "a")
+
+    // conn is past linger and maxLifetime but in use; not reaped
+    f := execute(a, 200ms)
+    Actor.sleep(100ms)
+    cp.checkLinger
+    verifyEq(debugInt(cp.debug, "entries"), 1)
+    verifyEq(debugInt(cp.debug, "inUse"), 1)
+    f.get
+
+    // once released and idle it is reaped
+    Actor.sleep(60ms)
+    cp.checkLinger
+    verifyEq(debugInt(cp.debug, "entries"), 0)
+    cp.close
+  }
+
+  Void testLeakWarn()
+  {
+    cp := SqlConnPool { it.uri = "test"; it.leakWarn = 50ms }
+    count := AtomicInt()
+    handler := |LogRec rec| { if (rec.msg.contains("held in-use")) count.increment }
+    Log.addHandler(handler)
+    try
+    {
+      ap := ActorPool()
+      a := SqlConnPoolTestActor(ap, cp, "a")
+
+      // hold past leakWarn; warns once even with multiple checks
+      f := execute(a, 200ms)
+      Actor.sleep(100ms)
+      cp.checkLinger
+      cp.checkLinger
+      verifyEq(count.val, 1)
+      f.get
+
+      // next long checkout warns again
+      f = execute(a, 200ms)
+      Actor.sleep(100ms)
+      cp.checkLinger
+      verifyEq(count.val, 2)
+      f.get
+    }
+    finally Log.removeHandler(handler)
+    cp.close
+  }
+
+  Void testCloseFailFast()
+  {
+    cp := SqlConnPool { it.uri = "test"; it.maxConns = 1; it.timeout = 5sec }
+    ap := ActorPool()
+    a1 := SqlConnPoolTestActor(ap, cp, "a1")
+    a2 := SqlConnPoolTestActor(ap, cp, "a2")
+
+    // a1 holds the only conn; a2 blocks waiting for it
+    f1 := execute(a1, 300ms)
+    f2 := a2.send(1ms)
+    Actor.sleep(50ms)
+
+    // close must wake a2 immediately, not wait out the timeout
+    start := Duration.now
+    cp.close
+    verifyErr(Err#) { f2.get }
+    verify(Duration.now - start < 2sec)
+    f1.get
+  }
+
+  Void testStress()
+  {
+    cp := SqlConnPool { it.uri = "test"; it.maxConns = 3; it.timeout = 10sec; it.linger = 100ms }
+    ap := ActorPool { it.maxThreads = 8 }
+    actors := SqlConnPoolStressActor[,]
+    8.times { actors.add(SqlConnPoolStressActor(ap, cp)) }
+
+    // fire away with random sleeps, errors, and broken conns
+    futures := Future[,]
+    actors.each |a| { 50.times { futures.add(a.send("go")) } }
+    futures.each |f| { verifyEq(f.get(30sec), "ok") }
+
+    // pool bounded and fully released, then drains after linger
+    verify(debugInt(cp.debug, "entries") <= 3)
+    verifyEq(debugInt(cp.debug, "inUse"), 0)
+    Actor.sleep(150ms)
+    cp.checkLinger
+    verifyEq(debugInt(cp.debug, "entries"), 0)
+    cp.close
+  }
+
   private Future execute(SqlConnPoolTestActor a, Duration wait)
   {
     f := a.send(wait)
@@ -179,5 +366,27 @@ internal const class SqlConnPoolTestActor : Actor
     return null
   }
 
+}
+
+internal const class SqlConnPoolStressActor : Actor
+{
+  new make(ActorPool ap, SqlConnPool cp) : super(ap) { this.cp = cp }
+
+  const SqlConnPool cp
+
+  override Obj? receive(Obj? msg)
+  {
+    try
+    {
+      cp.execute |c|
+      {
+        r := Int.random(0..9)
+        if (r > 6) Actor.sleep(1ms * (r-6).toFloat)
+        if (r == 0) { ((TestSqlConn)c).valid = false; throw Err("chaos") }
+      }
+    }
+    catch (Err e) { if (e.msg != "chaos") throw e }
+    return "ok"
+  }
 }
 


### PR DESCRIPTION
Bug Fixes:

- checkLinger() no longer closes connections that are in use.
- Fix pool debug() output.

Improvements:

- Validate pooled connections on borrow.
- Evict broken connections instead of releasing them.
- Roll back uncommited transactions on release, when not in auto-commit.
- Connections now have a bounded maximum lifetime.
- Don't hold the pool monitor during network I/O.
- Close connections outside pool lock
- Add connectTimeout
- Warn when connection held in-use past leakWarn
